### PR TITLE
Re-work download_live_ocean to get files via HTTPS

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -174,31 +174,27 @@ ssh:
 
 temperature salinity:
   download:
-    # Host name from which to download UW Live Ocean daily averaged forecast fields files
-    host: boiler-nowcast
-    # Passphrase-less deployment key used by automation for authentication
-    # on the host.
-    # The key-pair is assumed to be stored in $USER/.ssh/.
-    ssh key: SalishSeaNEMO-nowcast_id_rsa
-    # Template for UW Live Ocean daily averaged forecast fields file processing status
-    status file template: '/data1/parker/LiveOcean_roms/output/cas6_v3_lo8b/f{yyyymmdd}/ubc_done.txt'
-    # Template for UW Live Ocean daily averaged forecast fields path and file name on remote host
-    bc file template: '/data1/parker/LiveOcean_roms/output/cas6_v3_lo8b/f{yyyymmdd}/low_passed_UBC.nc'
-    # Destination directory for downloaded UW Live Ocean files
+    # Template for UW LiveOcean day-averaged forecast fields file processing status URL
+    # **Must be quoted to project {} characters**
+    status file url template: 'https://liveocean.apl.uw.edu/output/f{yyyymmdd}/ubc_done.txt'
+    # Template for UW LiveOcean day-averaged forecast fields file URL
+    # **Must be quoted to project {} characters**
+    bc file url template: 'https://liveocean.apl.uw.edu/output/f{yyyymmdd}/ubc.nc'
+    # Destination directory for downloaded UW LiveOcean files
     dest dir: /results/forcing/LiveOcean/downloaded/
-    # File name for local storage of UW Live Ocean daily averaged forecast file
+    # File name for local storage of UW LiveOcean day-averaged forecast file
     file name: low_passed_UBC.nc
 
   # Destination directory for daily temperature and salinity boundary conditions
-  # files generated from UW Live Ocean forecast
+  # files generated from UW LiveOcean forecast
   bc dir: /results/forcing/LiveOcean/boundary_conditions
   # File name template for the daily temperature and salinity boundary
-  # conditions files generated from UW Live Ocean forecast
+  # conditions files generated from UW LiveOcean forecast
   # **Must be quoted to project {} characters**
   file template: 'LiveOcean_v201905_{:y%Ym%md%d}.nc'
   # Mesh mask from which to get grid parameters for boundary conditions files
   mesh mask: /SalishSeaCast/grid/mesh_mask201702.nc
-  # Parameter set to use to convert from Live Ocean to SalishSeaCast
+  # Parameter set to use to convert from LiveOcean to SalishSeaCast
   parameter set: v201905
 
 

--- a/nowcast/lib.py
+++ b/nowcast/lib.py
@@ -134,7 +134,7 @@ def mkdir(
     are probably correct already.
 
     :arg path: Path to create the directory at.
-    :type path: str
+    :type path: :py:class:`pathlib.Path` or str
 
     :arg logger: Logger object.
     :type logger: :class:`logging.Logger`
@@ -147,7 +147,7 @@ def mkdir(
                    will be the same as its parent's.
     :type grp_name: str
 
-    :arg exist_ok: Indicate whether or not to log and error message and
+    :arg exist_ok: Indicate whether to log and error message and
                    raise an exception if path already exists.
                    Defaults to True meaning that an existing path is
                    accepted silently.

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -1046,7 +1046,7 @@ def _render_figures(
                 if model == "nemo"
                 else Path(config["figures"]["storage path"], model, run_type, dmy)
             )
-            lib.mkdir(os.fspath(fig_files_dir), logger, grp_name=config["file group"])
+            lib.mkdir(fig_files_dir, logger, grp_name=config["file group"])
         filename = fig_files_dir / f"{svg_name}_{dmy}.{fig_save_format}"
         if image_loop_figure:
             filename = fig_files_dir / f"{svg_name}.{fig_save_format}"

--- a/nowcast/workers/make_ssh_files.py
+++ b/nowcast/workers/make_ssh_files.py
@@ -190,9 +190,7 @@ def _copy_csv_to_results_dir(data_file, run_date, run_type, config):
     results_dir = Path(
         config["results archive"][run_type], results_date.format("DDMMMYY").lower()
     )
-    lib.mkdir(
-        os.fspath(results_dir), logger, grp_name=config["file group"], exist_ok=True
-    )
+    lib.mkdir(results_dir, logger, grp_name=config["file group"], exist_ok=True)
     shutil.copy2(data_file, results_dir)
     logger.debug(f"copied {data_file} to {results_dir}")
 


### PR DESCRIPTION
Parker changed files distribution from sftp from boiler to publishing them on
https://liveocean.apl.uw.edu/output/.

Also includes some drive-by maintenance on lib.mkdir() re: pathlib.Path.