### PR TITLE
Add logging config to separate hindcast logs

### DIFF
--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -1046,7 +1046,7 @@ def _render_figures(
                 if model == "nemo"
                 else Path(config["figures"]["storage path"], model, run_type, dmy)
             )
-            lib.mkdir(os.fspath(fig_files_dir), logger, grp_name=config["file group"])
+            lib.mkdir(fig_files_dir, logger, grp_name=config["file group"])
         filename = fig_files_dir / f"{svg_name}_{dmy}.{fig_save_format}"
         if image_loop_figure:
             filename = fig_files_dir / f"{svg_name}.{fig_save_format}"

--- a/nowcast/workers/make_ssh_files.py
+++ b/nowcast/workers/make_ssh_files.py
@@ -190,9 +190,7 @@ def _copy_csv_to_results_dir(data_file, run_date, run_type, config):
     results_dir = Path(
         config["results archive"][run_type], results_date.format("DDMMMYY").lower()
     )
-    lib.mkdir(
-        os.fspath(results_dir), logger, grp_name=config["file group"], exist_ok=True
-    )
+    lib.mkdir(results_dir, logger, grp_name=config["file group"], exist_ok=True)
     shutil.copy2(data_file, results_dir)
     logger.debug(f"copied {data_file} to {results_dir}")
 


### PR DESCRIPTION
Hindcast worker log message clutter production system log files,
so move them to separate log files: hindcast.log and hindcast.debug.log.

Also add production config unit tests for logging.publisher section.