### PR TITLE
arhcive_tarball worker

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -360,6 +360,13 @@ results archive:
     graham-dtn: /nearline/rrg-allen/SalishSea/nowcast-green.201905/
 
 
+# Config for archival storage of month-long tarballs of results
+# on a remote host; e.g. graham:/nearline/
+results tarballs:
+  # Local path with sufficient room to store ~1Tb tarball and index file
+  temporary tarball dir: /ocean/dlatorne/
+
+
 rolling forecasts:
   # Number of days prior to run date to include in forecast dataset
   days from past: 5
@@ -1471,6 +1478,16 @@ message registry:
       success hindcast: hindcast results files split into daily directories
       failure hindcast: hindcast results files splitting into daily directories failed
       crash: split_results worker crashed
+
+    archive_tarball:
+      checklist key: archived tarballs
+      success nowcast: nowcast results tarball archived
+      failure nowcast: nowcast results tarball archiving failed
+      success nowcast-green: nowcast-green results tarball archived
+      failure nowcast-green: nowcast-green results tarball archiving failed
+      success nowcast-agrif: nowcast-agrif results tarball archived
+      failure nowcast-agrif: nowcast-agrif results tarball archiving failed
+      crash: archive_tarball worker crashed
 
     download_wwatch3_results:
       checklist key: WWATCH3 results files

--- a/nowcast/workers/archive_tarball.py
+++ b/nowcast/workers/archive_tarball.py
@@ -1,0 +1,146 @@
+#  Copyright 2013 – present by the SalishSeaCast Project contributors
+#  and The University of British Columbia
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""SalishSeaCast worker that creates a tarball of a month's run results and
+moved to remote archival storage. Compression is *not* used for the tarball
+because the netCDF files that compose most of it are already highly compressed.
+A .index text file containing a list of the files in the tarball is also created
+and moved to the remote storage.
+"""
+import argparse
+import logging
+import os
+import stat
+import tarfile
+from pathlib import Path
+
+import arrow
+from nemo_nowcast import NowcastWorker
+
+NAME = "archive_tarball"
+logger = logging.getLogger(NAME)
+
+
+def main():
+    worker = NowcastWorker(NAME, description=__doc__)
+    worker.init_cli()
+    worker.cli.add_argument(
+        "run_type",
+        choices={
+            "nowcast",
+            "nowcast-green",
+            "nowcast-agrif",
+        },
+        help="Type of run to archive results files from.",
+    )
+    worker.cli.add_argument(
+        "yyyy_mmm",
+        type=_arrow_yyyy_mmm,
+        help="Year and month of run results to archive. Use YYYY-MMM format.",
+    )
+    worker.cli.add_argument(
+        "dest_host",
+        default="graham-dtn",
+        help="Name of the host to move tarball and index files to. Default is :kbd:`graham-dtn`.",
+    )
+    worker.run(archive_tarball, success, failure)
+    return worker
+
+
+def _arrow_yyyy_mmm(string):
+    """Convert a YYYY-MMM string to a UTC arrow object or raise
+    :py:exc:`argparse.ArgumentTypeError`.
+
+    The day part of the resulting arrow object is set to 01,
+    and the time part is set to 00:00:00.
+
+    :arg str string: YYYY-MMM string to convert.
+
+    :returns: Year-month string converted to a UTC :py:class:`arrow.Arrow` object.
+
+    :raises: :py:exc:`argparse.ArgumentTypeError`
+    """
+    try:
+        return arrow.get(string, "YYYY-MMM")
+    except arrow.parser.ParserError:
+        msg = f"unrecognized year-month format: {string} - please use YYYY-MMM"
+        raise argparse.ArgumentTypeError(msg)
+
+
+def success(parsed_args):
+    logger.info(
+        f'{parsed_args.run_type} {parsed_args.yyyy_mmm.format("*MMMYY").lower()} '
+        f"results files archived to {parsed_args.dest_host}"
+    )
+    msg_type = f"success {parsed_args.run_type}"
+    return msg_type
+
+
+def failure(parsed_args):
+    logger.critical(
+        f'{parsed_args.run_type} {parsed_args.yyyy_mmm.format("*MMMYY").lower()} '
+        f"results files archiving to {parsed_args.dest_host} failed"
+    )
+    msg_type = f"failure {parsed_args.run_type}"
+    return msg_type
+
+
+def archive_tarball(parsed_args, config, *args):
+    run_type = parsed_args.run_type
+    yyyy_mmm = parsed_args.yyyy_mmm.format('MMMYY').lower()
+    dest_host = parsed_args.dest_host
+    tmp_tarball_dir = Path(config["results tarballs"]["temporary tarball dir"])
+    run_type_results = Path(config["results archive"][run_type])
+    tarball = tmp_tarball_dir / f"{run_type_results.parts[-1]}-{yyyy_mmm}.tar"
+    results_path_pattern = run_type_results/f"*{yyyy_mmm}"
+    logger.info(f"creating {tarball} from {results_path_pattern}/")
+    _create_tarball(tarball, results_path_pattern)
+    logger.info(f"creating {tarball.with_suffix('.index')} from {tarball}")
+    _create_tarball_index(tarball)
+    return {
+        "tarball archived": {
+            "tarball": os.fspath(tarball),
+            "index": os.fspath(tarball.with_suffix(".index")),
+        }
+    }
+
+
+def _create_tarball(tarball, results_path_pattern):
+    with tarfile.open(tarball, "w") as tar:
+        results_dir = results_path_pattern.parent.parent
+        os.chdir(results_dir)
+        for p in sorted(results_path_pattern.parent.glob(results_path_pattern.parts[-1])):
+            logger.debug(f"adding {p}/ to {tarball}")
+            tar.add(p.relative_to(results_dir))
+
+
+def _create_tarball_index(tarball):
+    with tarball.with_suffix(".index").open("wt") as f:
+        with tarfile.open(tarball, "r") as tar:
+            for m in tar.getmembers():
+                mode_str = stat.filemode(m.mode)[1:]
+                mode = f"d{mode_str}" if m.isdir() else f"-{mode_str}"
+                name = f"{m.name}/" if m.isdir() else m.name
+                f.write(
+                    f"{mode} {m.gname}/{m.uname} {m.size:>10} "
+                    f"{arrow.get(m.mtime).format('YYYY-MM-DD HH:mm')} {name}\n"
+                )
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/tests/workers/test_archive_tarball.py
+++ b/tests/workers/test_archive_tarball.py
@@ -1,0 +1,216 @@
+#  Copyright 2013 – present by the SalishSeaCast Project contributors
+#  and The University of British Columbia
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""Unit tests for SalishSeaCast archive_tarball worker.
+"""
+import logging
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import arrow
+import nemo_nowcast
+import pytest
+
+from nowcast.workers import archive_tarball
+
+
+@pytest.fixture()
+def config(base_config):
+    """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
+    config_file = Path(base_config.file)
+    with config_file.open("at") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                results archive:
+                  nowcast: SalishSea/nowcast/
+                  nowcast-green: SalishSea/nowcast-green/
+                  nowcast-agrif: SalishSea/nowcast-agrif/
+
+                results tarballs:
+                  temporary tarball dir: ocean/dlatorne/
+                  graham-dtn: /nearline/rrg-allen/SalishSea/
+                """
+            )
+        )
+    config_ = nemo_nowcast.Config()
+    config_.load(config_file)
+    return config_
+
+
+@pytest.fixture
+def mock_worker(mock_nowcast_worker, monkeypatch):
+    monkeypatch.setattr(archive_tarball, "NowcastWorker", mock_nowcast_worker)
+
+
+class TestMain:
+    """Unit tests for main() function."""
+
+    def test_instantiate_worker(self, mock_worker):
+        worker = archive_tarball.main()
+        assert worker.name == "archive_tarball"
+        assert worker.description.startswith(
+            "SalishSeaCast worker that creates a tarball of a month's run results"
+        )
+
+    def test_add_run_type_arg(self, mock_worker):
+        worker = archive_tarball.main()
+        assert worker.cli.parser._actions[3].dest == "run_type"
+        expected = {
+            "nowcast",
+            "nowcast-green",
+            "nowcast-agrif",
+        }
+        assert worker.cli.parser._actions[3].choices == expected
+        assert worker.cli.parser._actions[3].help
+
+    def test_add_yyyy_mmm_arg(self, mock_worker):
+        worker = archive_tarball.main()
+        assert worker.cli.parser._actions[4].dest == "yyyy_mmm"
+        assert worker.cli.parser._actions[4].type == archive_tarball._arrow_yyyy_mmm
+        assert worker.cli.parser._actions[4].help
+
+    def test_add_dest_host_arg(self, mock_worker):
+        worker = archive_tarball.main()
+        assert worker.cli.parser._actions[5].dest == "dest_host"
+        assert worker.cli.parser._actions[5].default == "graham-dtn"
+        assert worker.cli.parser._actions[5].help
+
+
+class TestConfig:
+    """Unit tests for production YAML config file elements related to worker."""
+
+    def test_message_registry(self, prod_config):
+        assert "archive_tarball" in prod_config["message registry"]["workers"]
+        msg_registry = prod_config["message registry"]["workers"]["archive_tarball"]
+        assert msg_registry["checklist key"] == "archived tarballs"
+
+    def test_message_registry_keys(self, prod_config):
+        msg_registry = prod_config["message registry"]["workers"]["archive_tarball"]
+        assert list(msg_registry.keys()) == [
+            "checklist key",
+            "success nowcast",
+            "failure nowcast",
+            "success nowcast-green",
+            "failure nowcast-green",
+            "success nowcast-agrif",
+            "failure nowcast-agrif",
+            "crash",
+        ]
+
+    def test_results_tarballs(self, prod_config):
+        assert prod_config["results tarballs"]["temporary tarball dir"] == "/ocean/dlatorne/"
+
+    @pytest.mark.parametrize("run_type, results_path", (
+        ("nowcast", "/results/SalishSea/nowcast-blue.201905/"),
+        ("nowcast-green", "/results2/SalishSea/nowcast-green.201905/"),
+        ("nowcast-agrif", "/results/SalishSea/nowcast-agrif.201702/"),
+
+    ))
+    def test_results_archive(self, run_type, results_path, prod_config):
+        assert prod_config["results archive"][run_type] == results_path
+
+
+@pytest.mark.parametrize(
+    "run_type",
+    [
+        "nowcast",
+        "nowcast-green",
+        "nowcast-agrif",
+    ],
+)
+class TestSuccess:
+    """Unit tests for success() function."""
+
+    def test_success(self, run_type, caplog):
+        yyyy_mmm = arrow.get("2022-may", "YYYY-MMM")
+        dest_host = "graham-dtn"
+        parsed_args = SimpleNamespace(run_type=run_type, yyyy_mmm=yyyy_mmm, dest_host=dest_host)
+        caplog.set_level(logging.INFO)
+        msg_type = archive_tarball.success(parsed_args)
+        assert caplog.records[0].levelname == "INFO"
+        expected = (
+            f"{run_type} {yyyy_mmm.format('*MMMYY').lower()} "
+            f"results files archived to {dest_host}"
+        )
+        assert caplog.messages[0] == expected
+        assert msg_type == f"success {run_type}"
+
+
+@pytest.mark.parametrize(
+    "run_type",
+    [
+        "nowcast",
+        "nowcast-green",
+        "nowcast-agrif",
+    ],
+)
+class TestFailure:
+    """Unit tests for failure() function."""
+
+    def test_failure(self, run_type, caplog):
+        yyyy_mmm = arrow.get("2022-may", "YYYY-MMM")
+        dest_host = "graham-dtn"
+        parsed_args = SimpleNamespace(run_type=run_type, yyyy_mmm=yyyy_mmm, dest_host=dest_host)
+        caplog.set_level(logging.CRITICAL)
+        msg_type = archive_tarball.failure(parsed_args)
+        assert caplog.records[0].levelname == "CRITICAL"
+        expected = (
+            f"{run_type} {yyyy_mmm.format('*MMMYY').lower()} "
+            f"results files archiving to {dest_host} failed"
+        )
+        assert caplog.messages[0] == expected
+        assert msg_type == f"failure {run_type}"
+
+
+class TestArchiveTarball:
+    """Unit tests for archive_tarball() function."""
+
+    def test_checklist(self, config, caplog, monkeypatch):
+        def mock_create_tarball(tarball, results_path_pattern):
+            pass
+
+        monkeypatch.setattr(archive_tarball, "_create_tarball", mock_create_tarball)
+
+        def mock_create_tarball_index(tarball):
+            pass
+
+        monkeypatch.setattr(archive_tarball, "_create_tarball_index", mock_create_tarball_index)
+
+        yyyy_mmm = arrow.get("2022-may", "YYYY-MMM")
+        parsed_args = SimpleNamespace(run_type="nowcast-green", yyyy_mmm=yyyy_mmm, dest_host="graham-dtn")
+        caplog.set_level(logging.INFO)
+        checklist = archive_tarball.archive_tarball(parsed_args, config)
+        assert caplog.records[0].levelname == "INFO"
+        expected = (
+            "creating ocean/dlatorne/nowcast-green-may22.tar from SalishSea/nowcast-green/*may22/"
+        )
+        assert caplog.messages[0] == expected
+        expected = (
+            "creating ocean/dlatorne/nowcast-green-may22.index from "
+            "ocean/dlatorne/nowcast-green-may22.tar"
+        )
+        assert caplog.messages[1] == expected
+        expected = {
+            "tarball archived": {
+                "tarball": "ocean/dlatorne/nowcast-green-may22.tar",
+                "index": "ocean/dlatorne/nowcast-green-may22.index",
+            }
+        }
+        assert checklist == expected


### PR DESCRIPTION
Creates a tarball of a month's run results and
moves it to remote archival storage. Compression is *not* used for the tarball
because the netCDF files that compose most of it are already highly compressed.
A .index text file containing a list of the files in the tarball is also created
and moved to the remote storage.