### PR TITLE
Add test for after_*() functions & missing after_archive_tarball()

### DIFF
--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1425,6 +1425,26 @@ def after_download_results(msg, config, checklist):
     return next_workers[msg.type]
 
 
+def after_archive_tarball(msg, config, checklist):
+    """Calculate the list of workers to launch after the archive_tarball worker ends.
+
+    :arg msg: Nowcast system message.
+    :type msg: :py:class:`nemo_nowcast.message.Message`
+
+    :arg config: :py:class:`dict`-like object that holds the nowcast system
+                 configuration that is loaded from the system configuration
+                 file.
+    :type config: :py:class:`nemo_nowcast.config.Config`
+
+    :arg dict checklist: System checklist: data structure containing the
+                         present state of the nowcast system.
+
+    :returns: Worker(s) to launch next
+    :rtype: list
+    """
+    return []
+
+
 def after_make_CHS_currents_file(msg, config, checklist):
     """Calculate the list of workers to launch after the make_CHS_currents_file
     worker ends.

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -18,6 +18,7 @@
 
 """Unit tests for nowcast.next_workers module.
 """
+import inspect
 import textwrap
 from pathlib import Path
 
@@ -120,6 +121,26 @@ def checklist():
     a mock for :py:attr:`nemo_nowcast.manager.NowcastManager.checklist`.
     """
     return {}
+
+
+class TestAfterWorkerFunctions:
+    """Unit test to confirm that all worker modules have a corresponding after_*() function
+    in the next_workers module.
+    """
+
+    def test_all_workers_have_after_functions(self):
+        def worker_modules():
+            for module in Path("../nowcast/workers/").glob("*.py"):
+                if module.name != "__init__.py":
+                    yield module
+
+        after_funcs = {
+            func[0] for func in inspect.getmembers(next_workers, inspect.isfunction)
+        }
+        for module in worker_modules():
+            # if module.stem in {"archive_tarball"}:
+            #     continue
+            assert f"after_{module.stem}" in after_funcs
 
 
 class TestAfterDownloadWeather:

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2187,6 +2187,28 @@ class TestAfterDownloadResults:
         assert expected in workers
 
 
+class TestAfterArchiveTarball:
+    """Unit tests for the after_archive_tarball function."""
+
+    @pytest.mark.parametrize(
+        "msg_type",
+        [
+            "crash",
+            "success nowcast",
+            "failure nowcast",
+            "success nowcast-green",
+            "failure nowcast-green",
+            "success nowcast-agrif",
+            "failure nowcast-agrif",
+        ],
+    )
+    def test_no_next_worker_msg_types(self, msg_type, config, checklist):
+        workers = next_workers.after_archive_tarball(
+            Message("archive_tarball", msg_type), config, checklist
+        )
+        assert workers == []
+
+
 class TestAfterMakeCHSCurrentsFile:
     """Unit tests for the after_make_CHS_currents_file function."""
 


### PR DESCRIPTION
New test inspects `next_workers` module to confirm that it contains an `after_*()` function
for each of the worker modules in `nowcast/workers/`.

Prompted by having missed the addition of the `after_archive_tarball()` function in PR#104.