### PR TITLE
Handle missing Neah Bay sea surface height obs by symlink to forecast file

### DIFF
--- a/nowcast/workers/make_ssh_files.py
+++ b/nowcast/workers/make_ssh_files.py
@@ -263,7 +263,7 @@ def _save_netcdf(day, tc, surges, forecast_flag, textfile, config, lats, lons):
         filepath = os.path.join(save_path, "obs", filename)
         try:
             # Unlink file path in case it exists as a symlink to a fcst/
-            # file created byh upload_forcing worker because there was
+            # file created by upload_forcing worker because there was
             # no obs/ file
             os.unlink(filepath)
         except OSError:


### PR DESCRIPTION
This moves handling of the exception case of persisting forecast values as observations when obs are missing/incomplete from `upload_forcing` to `make_ssh_files`. Doing so should avoid the symlink/file-exists race conditions that often arises when `upload_forcing` tries to create the symlink.