### PR TITLE
Change run sequence to run wwatch3 nowcast & forecast after NEMO forecast

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -675,7 +675,7 @@ wave forecasts:
   # NEMO run to run wwatch3 forecast run after
   # User 'after forecast' during storm surge season and 'after nowcast-green`
   # the rest of the year
-  run when: after nowcast-green
+  run when: after forecast
   # Directory on compute host where files (e.g. ww3_*.inp,  mod_def.ww3) and
   # directories (e,g. wind/ current/) necessary to prepare the wwatch3 runs
   # are stored

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1340,6 +1340,17 @@ def after_watch_ww3(msg, config, checklist):
                     host=msg.payload[run_type]["host"],
                 )
             )
+        if run_type == "forecast":
+            wave_forecast_after = config["wave forecasts"]["run when"].split("after ")[
+                1
+            ]
+            if wave_forecast_after == "forecast":
+                next_workers[msg.type].append(
+                    NextWorker(
+                        "nowcast.workers.make_turbidity_file",
+                        args=["--run-date", msg.payload[run_type]["run date"]],
+                    )
+                )
     return next_workers[msg.type]
 
 

--- a/nowcast/workers/watch_ww3.py
+++ b/nowcast/workers/watch_ww3.py
@@ -12,8 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Salish Sea nowcast worker that monitors and reports on the
-progress of a WaveWatch3 run on the ONC cloud computing facility.
+"""Salish Sea nowcast worker that monitors and reports on the progress of a WaveWatch3 run
+ on the ONC cloud computing facility.
 """
 import logging
 import os
@@ -39,7 +39,11 @@ def main():
     """
     worker = NowcastWorker(NAME, description=__doc__)
     worker.init_cli()
-    worker.cli.add_argument("host_name", help="Name of the host to monitor the run on")
+    worker.cli.add_argument(
+        "host_name",
+        default="arbutus.cloud-nowcast",
+        help="Name of the host to monitor the run on",
+    )
     worker.cli.add_argument(
         "run_type",
         choices={"nowcast", "forecast", "forecast2"},
@@ -51,6 +55,7 @@ def main():
         """,
     )
     worker.run(watch_ww3, success, failure)
+    return worker
 
 
 def success(parsed_args):

--- a/nowcast/workers/watch_ww3.py
+++ b/nowcast/workers/watch_ww3.py
@@ -123,13 +123,16 @@ def watch_ww3(parsed_args, config, tell_manager):
 
 def _find_run_pid(run_info):
     run_exec_cmd = run_info["run exec cmd"]
-    cmd = shlex.split(f'pgrep --newest --exact --full "{run_exec_cmd}"')
-    logger.debug(f'searching processes for "{run_exec_cmd}"')
+    cmd = f'pgrep --newest --exact --full "{run_exec_cmd}"'
+    logger.debug(f"searching processes with `{cmd}`")
     pid = None
     while pid is None:
         try:
             proc = subprocess.run(
-                cmd, stdout=subprocess.PIPE, check=True, universal_newlines=True
+                shlex.split(cmd),
+                stdout=subprocess.PIPE,
+                check=True,
+                universal_newlines=True,
             )
             pid = int(proc.stdout)
         except subprocess.CalledProcessError:

--- a/nowcast/workers/watch_ww3.py
+++ b/nowcast/workers/watch_ww3.py
@@ -60,17 +60,17 @@ def main():
 
 def success(parsed_args):
     logger.info(
-        "{0.run_type} WWATCH3 run on {0.host_name} completed".format(parsed_args)
+        f"{parsed_args.run_type} WWATCH3 run on {parsed_args.host_name} completed"
     )
-    msg_type = "success {.run_type}".format(parsed_args)
+    msg_type = f"success {parsed_args.run_type}"
     return msg_type
 
 
 def failure(parsed_args):
     logger.critical(
-        "{0.run_type} WWATCH3 run on {0.host_name} failed".format(parsed_args)
+        f"{parsed_args.run_type} WWATCH3 run on {parsed_args.host_name} failed"
     )
-    msg_type = "failure {.run_type}".format(parsed_args)
+    msg_type = f"failure {parsed_args.run_type}"
     return msg_type
 
 

--- a/nowcast/workers/watch_ww3.py
+++ b/nowcast/workers/watch_ww3.py
@@ -88,6 +88,7 @@ def watch_ww3(parsed_args, config, tell_manager):
             with (run_dir / "log.ww3").open("rt") as f:
                 lines = f.readlines()
             lines.reverse()
+            time_step = 0
             for line in lines:
                 try:
                     time_step = int(line.split()[0])

--- a/tests/workers/test_watch_ww3.py
+++ b/tests/workers/test_watch_ww3.py
@@ -58,6 +58,29 @@ class TestMain:
         assert worker.cli.parser._actions[4].help
 
 
+class TestConfig:
+    """Unit tests for production YAML config file elements related to worker."""
+
+    def test_message_registry(self, prod_config):
+        assert "watch_ww3" in prod_config["message registry"]["workers"]
+        msg_registry = prod_config["message registry"]["workers"]["watch_ww3"]
+        assert msg_registry["checklist key"] == "WWATCH3 run"
+
+    def test_message_registry_keys(self, prod_config):
+        msg_registry = prod_config["message registry"]["workers"]["watch_ww3"]
+        assert list(msg_registry.keys()) == [
+            "checklist key",
+            "need",
+            "success forecast2",
+            "failure forecast2",
+            "success nowcast",
+            "failure nowcast",
+            "success forecast",
+            "failure forecast",
+            "crash",
+        ]
+
+
 @pytest.mark.parametrize(
     "run_type, host_name",
     (


### PR DESCRIPTION
This is running wwatch3 after NEMO physics-only runs instead of after nowcast-green. Doing this for winter storm surge season when timely wave forecasts to support storm surge alerts are more useful/interesting than more or less dormant biology.

A bunch of test suite maintenance is also included.