### PR TITLE
Drop make_averaged_dataset from hindcast automation

### DIFF
--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1548,23 +1548,6 @@ def after_split_results(msg, config, checklist):
         "success hindcast": [],
     }
     if msg.type.startswith("success"):
-        for run_date in map(arrow.get, msg.payload):
-            next_workers[msg.type].extend(
-                [
-                    NextWorker(
-                        "nowcast.workers.make_averaged_dataset",
-                        args=[
-                            "salish-nowcast",
-                            "day",
-                            var_group,
-                            "--run-date",
-                            run_date.format("YYYY-MM-DD"),
-                        ],
-                        host="salish-nowcast",
-                    )
-                    for var_group in ("biology", "chemistry", "physics")
-                ]
-            )
         if config["results tarballs"]["archive hindcast"]:
             last_date = max(map(arrow.get, msg.payload))
             if arrow.get(last_date).shift(days=+1).day == 1:

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2329,45 +2329,6 @@ class TestAfterSplitResults:
         )
         assert workers == []
 
-    def test_success_launch_make_averaged_dataset_for_days(
-        self, config, checklist, monkeypatch
-    ):
-        msg = Message(
-            "split_results",
-            "success hindcast",
-            payload={
-                "2022-11-21",
-                "2022-11-22",
-                "2022-11-23",
-                "2022-11-24",
-                "2022-11-25",
-            },
-        )
-        workers = next_workers.after_split_results(
-            msg,
-            config,
-            checklist,
-        )
-        expected = []
-        for run_date in msg.payload:
-            expected.extend(
-                [
-                    NextWorker(
-                        "nowcast.workers.make_averaged_dataset",
-                        args=[
-                            "salish-nowcast",
-                            "day",
-                            var_group,
-                            "--run-date",
-                            arrow.get(run_date).format("YYYY-MM-DD"),
-                        ],
-                        host="salish-nowcast",
-                    )
-                    for var_group in ("biology", "chemistry", "physics")
-                ]
-            )
-        assert workers == expected
-
     def test_success_not_archive_hindcast_notlaunch_archive_tarball_hindcast(
         self, config, checklist, monkeypatch
     ):
@@ -2388,7 +2349,6 @@ class TestAfterSplitResults:
             "nowcast.workers.archive_tarball",
             args=["hindcast", "2022-nov", "graham-dtn"],
         )
-        assert len(workers) == 15
         assert archive_tarball not in workers
 
     def test_success_archive_hindcast_monthend_launch_archive_tarball_hindcast(
@@ -2440,7 +2400,6 @@ class TestAfterSplitResults:
             "nowcast.workers.archive_tarball",
             args=["hindcast", "2022-oct", "graham-dtn"],
         )
-        assert len(workers) == 15
         assert archive_tarball not in workers
 
 


### PR DESCRIPTION
The 15-18 `reshapr extract` jobs that this generated per optimum hindcast run seems to be too much for the dask cluster on salish, resulting in an unacceptably high job failure rate of ~20%.

Tests of day-by-day processing (3 concurrent reshapr jobs) as will happen when we add make_averaged_dataset to automation for nowcast-green.202111 showed nearly 100% reliability. So, processing of hindcast will be handled outside of automation.