### PR TITLE
Chg numpy.asscalar() calls to numpy.ndarray.item()

### DIFF
--- a/nowcast/workers/make_feeds.py
+++ b/nowcast/workers/make_feeds.py
@@ -248,8 +248,8 @@ def _calc_wind_4h_avg(feed, max_ssh_time, config):
     )
     wind_vector = wind_tools.wind_speed_dir(wind_avg.u, wind_avg.v)
     return {
-        "wind_speed_4h_avg": np.asscalar(wind_vector.speed),
-        "wind_dir_4h_avg": np.asscalar(wind_vector.dir),
+        "wind_speed_4h_avg": wind_vector.speed.item(),
+        "wind_dir_4h_avg": wind_vector.dir.item(),
     }
 
 

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -356,8 +356,8 @@ class TestMakeAveragedDataset:
             return nc_path
 
         monkeypatch.setattr(
-            make_averaged_dataset.reshapr.api.v1.extract,
-            "extract_netcdf",
+            make_averaged_dataset,
+            "_extract_netcdf",
             mock_extract_netcdf,
         )
 
@@ -408,8 +408,8 @@ class TestMakeAveragedDataset:
             return nc_path
 
         monkeypatch.setattr(
-            make_averaged_dataset.reshapr.api.v1.extract,
-            "extract_netcdf",
+            make_averaged_dataset,
+            "_extract_netcdf",
             mock_extract_netcdf,
         )
 


### PR DESCRIPTION
re: Deprecation of `numpy.asscalar()` in numpy=1.16 and its removal in numpy=1.23.