### PR TITLE
Change to run wwatch3 after NEMO nowcast-green

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -740,7 +740,7 @@ wave forecasts:
   # NEMO run to run wwatch3 forecast run after
   # User 'after forecast' during storm surge season and 'after nowcast-green`
   # the rest of the year
-  run when: after forecast
+  run when: after nowcast-green
   # Directory on compute host where files (e.g. ww3_*.inp,  mod_def.ww3) and
   # directories (e,g. wind/ current/) necessary to prepare the wwatch3 runs
   # are stored

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -132,7 +132,7 @@ class TestConfig:
 
     def test_wave_forecasts_run_when(self, prod_config):
         wave_fcsts = prod_config["wave forecasts"]
-        assert wave_fcsts["run when"] == "after forecast"
+        assert wave_fcsts["run when"] == "after nowcast-green"
 
 
 class TestAfterWorkerFunctions:


### PR DESCRIPTION
Instead of after NEMO forecast. This is for outside storm surge season when biology is more important to use than early wave forecasts.