### PR TITLE
Do make_turbidity_file after collect_weather 12

### DIFF
--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -100,6 +100,7 @@ def after_download_weather(msg, config, checklist):
                 )
             next_workers["success 2.5km 12"].extend(
                 [
+                    NextWorker("nowcast.workers.make_turbidity_file"),
                     NextWorker("nowcast.workers.collect_NeahBay_ssh", args=["06"]),
                     # NextWorker("nowcast.workers.grib_to_netcdf", args=["nowcast+"]),
                     NextWorker("nowcast.workers.download_live_ocean"),
@@ -756,13 +757,6 @@ def after_watch_NEMO(msg, config, checklist):
                     ]
                 )
                 race_condition_workers = {"make_ww3_wind_file", "make_ww3_current_file"}
-            else:
-                next_workers[msg.type].append(
-                    NextWorker(
-                        "nowcast.workers.make_turbidity_file",
-                        args=["--run-date", msg.payload[run_type]["run date"]],
-                    )
-                )
         if run_type == "nowcast-green":
             if wave_forecast_after == "nowcast-green":
                 host_name = config["wave forecasts"]["host"]
@@ -1372,29 +1366,19 @@ def after_watch_ww3(msg, config, checklist):
             )
         )
         if run_type == "nowcast":
-            next_workers[msg.type].append(
-                NextWorker(
-                    "nowcast.workers.run_ww3",
-                    args=[
-                        msg.payload[run_type]["host"],
-                        "forecast",
-                        "--run-date",
-                        msg.payload[run_type]["run date"],
-                    ],
-                    host=msg.payload[run_type]["host"],
-                )
-            )
-        if run_type == "forecast":
-            wave_forecast_after = config["wave forecasts"]["run when"].split("after ")[
-                1
-            ]
-            if wave_forecast_after == "forecast":
-                next_workers[msg.type].append(
-                    NextWorker(
-                        "nowcast.workers.make_turbidity_file",
-                        args=["--run-date", msg.payload[run_type]["run date"]],
-                    )
-                )
+            pass
+            # next_workers[msg.type].append(
+            #     NextWorker(
+            #         "nowcast.workers.run_ww3",
+            #         args=[
+            #             msg.payload[run_type]["host"],
+            #             "forecast",
+            #             "--run-date",
+            #             msg.payload[run_type]["run date"],
+            #         ],
+            #         host=msg.payload[run_type]["host"],
+            #     )
+            # )
     return next_workers[msg.type]
 
 

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -234,6 +234,7 @@ class TestAfterDownloadWeather:
                 ["USGS", "SkagitMountVernon", "--data-date", "2018-12-26"],
                 host="localhost",
             ),
+            NextWorker("nowcast.workers.make_turbidity_file", [], host="localhost"),
             NextWorker("nowcast.workers.collect_NeahBay_ssh", ["06"], host="localhost"),
             # NextWorker(
             #     "nowcast.workers.grib_to_netcdf", ["nowcast+"], host="localhost"
@@ -326,6 +327,7 @@ class TestAfterCollectWeather:
                 ["USGS", "SkagitMountVernon", "--data-date", "2018-12-26"],
                 host="localhost",
             ),
+            NextWorker("nowcast.workers.make_turbidity_file", [], host="localhost"),
             NextWorker("nowcast.workers.collect_NeahBay_ssh", ["06"], host="localhost"),
             # NextWorker(
             #     "nowcast.workers.grib_to_netcdf", ["nowcast+"], host="localhost"
@@ -1045,29 +1047,6 @@ class TestAfterWatchNEMO:
             ),
         ]
         assert workers == expected
-
-    def test_success_forecast_launch_make_turbidity_file(self, config, checklist):
-        workers = next_workers.after_watch_NEMO(
-            Message(
-                "watch_NEMO",
-                "success forecast",
-                {
-                    "forecast": {
-                        "host": "arbutus.cloud",
-                        "run date": "2017-08-10",
-                        "completed": True,
-                    }
-                },
-            ),
-            config,
-            checklist,
-        )
-        expected = NextWorker(
-            "nowcast.workers.make_turbidity_file",
-            args=["--run-date", "2017-08-10"],
-            host="localhost",
-        )
-        assert workers[0] == expected
 
     def test_success_forecast_launch_make_ww3_wind_file_forecast(
         self, config, checklist, monkeypatch
@@ -1956,53 +1935,6 @@ class TestAfterWatchWW3:
                 msg.payload[run_type]["run date"],
             ],
             host="arbutus.cloud",
-        )
-        assert expected in workers
-
-    def test_success_forecast_no_launch_make_turbidity_file(self, config, checklist):
-        """config["wave forcasts"]["run when"] == "after nowcast-green" case"""
-        msg = Message(
-            "watch_ww3",
-            "success forecast",
-            {
-                "forecast": {
-                    "host": "arbutus.cloud",
-                    "run date": "2022-11-08",
-                    "completed": True,
-                }
-            },
-        )
-        workers = next_workers.after_watch_ww3(msg, config, checklist)
-        run_type = msg.type.split()[1]
-        not_expected = NextWorker(
-            "nowcast.workers.make_turbidity_file",
-            args=["--run-date", msg.payload[run_type]["run date"]],
-            host="localhost",
-        )
-        assert not_expected not in workers
-
-    def test_success_forecast_launch_make_turbidity_file(
-        self, config, checklist, monkeypatch
-    ):
-        """config["wave forcasts"]["run when"] == "after forecast" case"""
-        msg = Message(
-            "watch_ww3",
-            "success forecast",
-            {
-                "forecast": {
-                    "host": "arbutus.cloud",
-                    "run date": "2022-11-08",
-                    "completed": True,
-                }
-            },
-        )
-        monkeypatch.setitem(config["wave forecasts"], "run when", "after forecast")
-        workers = next_workers.after_watch_ww3(msg, config, checklist)
-        run_type = msg.type.split()[1]
-        expected = NextWorker(
-            "nowcast.workers.make_turbidity_file",
-            args=["--run-date", msg.payload[run_type]["run date"]],
-            host="localhost",
         )
         assert expected in workers
 


### PR DESCRIPTION
This puts make_turbidity_file in the main flow of data collection and forcing file generation so that it happens regardless of what model runs are to be executed.