### PR TITLE
Change to run grib_to_netcdf on salish

### DIFF
--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -80,13 +80,15 @@ def after_download_weather(msg, config, checklist):
                 next_workers["success 2.5km 06"].extend(
                     [
                         NextWorker("nowcast.workers.collect_NeahBay_ssh", args=["00"]),
-                        # NextWorker(
-                        #     "nowcast.workers.grib_to_netcdf", args=["forecast2"]
-                        # ),
+                        NextWorker(
+                            "nowcast.workers.grib_to_netcdf",
+                            args=["forecast2"],
+                            host="salish-nowcast",
+                        ),
                     ]
                 )
                 race_condition_workers = {
-                    # "grib_to_netcdf",
+                    "grib_to_netcdf",
                     "make_ssh_files",
                 }
                 return next_workers[msg.type], race_condition_workers
@@ -102,12 +104,16 @@ def after_download_weather(msg, config, checklist):
                 [
                     NextWorker("nowcast.workers.make_turbidity_file"),
                     NextWorker("nowcast.workers.collect_NeahBay_ssh", args=["06"]),
-                    # NextWorker("nowcast.workers.grib_to_netcdf", args=["nowcast+"]),
+                    NextWorker(
+                        "nowcast.workers.grib_to_netcdf",
+                        args=["nowcast+"],
+                        host="salish-nowcast",
+                    ),
                     NextWorker("nowcast.workers.download_live_ocean"),
                 ]
             )
             race_condition_workers = {
-                # "grib_to_netcdf",
+                "grib_to_netcdf",
                 "make_live_ocean_files",
                 "make_ssh_files",
             }

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -207,13 +207,13 @@ class TestAfterDownloadWeather:
             NextWorker("nowcast.workers.get_onc_ctd", ["SEVIP"], host="localhost"),
             NextWorker("nowcast.workers.get_onc_ctd", ["USDDL"], host="localhost"),
             NextWorker("nowcast.workers.collect_NeahBay_ssh", ["00"], host="localhost"),
-            # NextWorker(
-            #     "nowcast.workers.grib_to_netcdf", ["forecast2"], host="localhost"
-            # ),
+            NextWorker(
+                "nowcast.workers.grib_to_netcdf", ["forecast2"], host="salish-nowcast"
+            ),
         ]
         assert workers == expected
         assert race_condition_workers == {
-            # "grib_to_netcdf",
+            "grib_to_netcdf",
             "make_ssh_files",
         }
 
@@ -234,14 +234,14 @@ class TestAfterDownloadWeather:
             ),
             NextWorker("nowcast.workers.make_turbidity_file", [], host="localhost"),
             NextWorker("nowcast.workers.collect_NeahBay_ssh", ["06"], host="localhost"),
-            # NextWorker(
-            #     "nowcast.workers.grib_to_netcdf", ["nowcast+"], host="localhost"
-            # ),
+            NextWorker(
+                "nowcast.workers.grib_to_netcdf", ["nowcast+"], host="salish-nowcast"
+            ),
             NextWorker("nowcast.workers.download_live_ocean", [], host="localhost"),
         ]
         assert workers == expected
         assert race_condition_workers == {
-            # "grib_to_netcdf",
+            "grib_to_netcdf",
             "make_live_ocean_files",
             "make_ssh_files",
         }
@@ -297,18 +297,15 @@ class TestAfterCollectWeather:
             NextWorker("nowcast.workers.get_onc_ctd", ["SEVIP"], host="localhost"),
             NextWorker("nowcast.workers.get_onc_ctd", ["USDDL"], host="localhost"),
             NextWorker("nowcast.workers.collect_NeahBay_ssh", ["00"], host="localhost"),
-            # NextWorker(
-            #     "nowcast.workers.grib_to_netcdf", ["forecast2"], host="localhost"
-            # ),
+            NextWorker(
+                "nowcast.workers.grib_to_netcdf", ["forecast2"], host="salish-nowcast"
+            ),
             NextWorker(
                 "nowcast.workers.collect_weather", ["12", "2.5km"], host="localhost"
             ),
         ]
         assert workers == expected
-        assert race_condition_workers == {
-            # "grib_to_netcdf",
-            "make_ssh_files"
-        }
+        assert race_condition_workers == {"grib_to_netcdf", "make_ssh_files"}
 
     def test_success_2_5_km_12(self, config, checklist, monkeypatch):
         def mock_now():
@@ -327,9 +324,9 @@ class TestAfterCollectWeather:
             ),
             NextWorker("nowcast.workers.make_turbidity_file", [], host="localhost"),
             NextWorker("nowcast.workers.collect_NeahBay_ssh", ["06"], host="localhost"),
-            # NextWorker(
-            #     "nowcast.workers.grib_to_netcdf", ["nowcast+"], host="localhost"
-            # ),
+            NextWorker(
+                "nowcast.workers.grib_to_netcdf", ["nowcast+"], host="salish-nowcast"
+            ),
             NextWorker("nowcast.workers.download_live_ocean", [], host="localhost"),
             NextWorker(
                 "nowcast.workers.collect_weather", ["18", "2.5km"], host="localhost"
@@ -337,7 +334,7 @@ class TestAfterCollectWeather:
         ]
         assert workers == expected
         assert race_condition_workers == {
-            # "grib_to_netcdf",
+            "grib_to_netcdf",
             "make_live_ocean_files",
             "make_ssh_files",
         }


### PR DESCRIPTION
`grib_to_netcdf`, after refactor for HRDPS continental grid, uses dask and needs lots of memory. So, use the persistent dask cluster on salish.