### PR TITLE
Update `collect_weather` worker re: changes in `watchdog=2.1.7`

### DIFF
--- a/nowcast/workers/collect_weather.py
+++ b/nowcast/workers/collect_weather.py
@@ -135,7 +135,7 @@ def collect_weather(parsed_args, config, *args):
             expected_files, grib_dir / forecast_yyyymmdd / forecast, grp_name
         )
         observer = watchdog.observers.Observer()
-        observer.schedule(handler, os.fspath(datamart_dir / forecast), recursive=True)
+        observer.schedule(handler, datamart_dir / forecast, recursive=True)
         logger.info(f"starting to watch for files in {datamart_dir/forecast}/")
         observer.start()
         while expected_files:
@@ -208,7 +208,7 @@ def _move_file(expected_file, grib_forecast_dir, grp_name):
     """
     grib_hour_dir = grib_forecast_dir / expected_file.parent.stem
     lib.mkdir(grib_hour_dir, logger, grp_name=grp_name)
-    shutil.move(os.fspath(expected_file), os.fspath(grib_hour_dir))
+    shutil.move(expected_file, grib_hour_dir)
     logger.debug(f"moved {expected_file} to {grib_hour_dir}/")
 
 

--- a/tests/workers/test_collect_weather.py
+++ b/tests/workers/test_collect_weather.py
@@ -391,7 +391,13 @@ class TestCollectWeather:
             def schedule(self, event_handler, path, recursive):
                 pass
 
+            def join(self):
+                pass
+
             def start(self):
+                pass
+
+            def stop(self):
                 pass
 
         monkeypatch.setattr(


### PR DESCRIPTION
Mostly change how the watchdog observer thread is controlled re: checking if all of the expected files have been downloaded. This fixes the problem of the worker not collecting files that arose after the change to the HRDPS continental grid.

Also drop some no longer necessary `os.fspath()` calls.