### PR TITLE
Change smelt rivers namelist for arbutus runs

### DIFF
--- a/nowcast/workers/run_NEMO.py
+++ b/nowcast/workers/run_NEMO.py
@@ -315,7 +315,7 @@ def _run_description(run_date, run_type, run_id, restart_timestep, host_name, co
         ]
         namelist_smelt_sections = (
             "namelist_smelt_biology",
-            "namelist_smelt_rivers",
+            "namelist_smelt_rivers.arbutus",
             "namelist_smelt_skog",
         )
         namelists["namelist_smelt_cfg"] = [

--- a/tests/workers/test_run_NEMO.py
+++ b/tests/workers/test_run_NEMO.py
@@ -956,7 +956,7 @@ class TestRunDescription:
         assert run_desc["namelists"]["namelist_top_cfg"] == expected
         expected = [
             str(tmp_run_sets.join("namelist_smelt_biology")),
-            str(tmp_run_sets.join("namelist_smelt_rivers")),
+            str(tmp_run_sets.join("namelist_smelt_rivers.arbutus")),
             str(tmp_run_sets.join("namelist_smelt_skog")),
         ]
         assert run_desc["namelists"]["namelist_smelt_cfg"] == expected


### PR DESCRIPTION
Rivers forcing directory is flatter on arbutus than elsewhere. Turbidity forcing files are stored beside discharge files rather than in a sub-dir.