### PR TITLE
Change sarrcenia clients to use queues on dd.weather.gc.ca

### DIFF
--- a/config/supervisord.ini
+++ b/config/supervisord.ini
@@ -44,7 +44,7 @@ autorestart = true
 
 [program:sr_subscribe-hrdps-continental]
 # Use `sr_subscribe foreground` instead of `start` to enable supervisor to manage the process
-command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hrdps-continental-hpfx.conf
+command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hrdps-continental-dd-weather.conf
 # sr_subscribe logs to stderr; redirect that to stdout so that we can
 # view the sr_subscribe log with `supervisorctl tail sr_subscribe-hrdps-continental`
 redirect_stderr = true
@@ -53,7 +53,7 @@ autorestart = true
 
 [program:sr_subscribe-hydrometric]
 # Use `sr_subscribe foreground` instead of `start` to enable supervisor to manage the process
-command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hydrometric-hpfx.conf
+command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hydrometric-dd-weather.conf
 # sr_subscribe logs to stderr; redirect that to stdout so that we can
 # view the sr_subscribe log with `supervisorctl tail sr_subscribe-hydrometric`
 redirect_stderr = true

--- a/sarracenia/hrdps-continental-dd-weather.conf
+++ b/sarracenia/hrdps-continental-dd-weather.conf
@@ -1,0 +1,40 @@
+broker amqps://anonymous@dd.weather.gc.ca
+queue_name q_anonymous.sr_subscribe.hrdps-continental-dd-weather.UBC.SalishSeaCast
+instances 1
+expire 6h
+
+subtopic model_hrdps.continental.2.5km.#
+directory /SalishSeaCast/datamart/hrdps-continental/
+# mirror the datamart directory structure but drop the 1st 4 path elements
+# so that our mirror starts with forecast number (00/, 06/, 12/, or 18/)
+mirror true
+strip 4
+
+# we only want 001/ directories onward
+reject .*?/000/.*
+# don't want WEonG (Weather Elements on Grid) version of variables
+reject .*WEonG_PRATE_Sfc.*
+reject .*WEonG_FZPRATE_Sfc.*
+
+# u component of wind velocity at 10m elevation
+accept .*UGRD_AGL-10m.*
+# v component of wind velocity at 10m elevation
+accept .*VGRD_AGL-10m.*
+# accumulated downward shortwave (solar) radiation at ground level
+accept .*DSWRF_Sfc.*
+# accumulated downward longwave (thermal) radiation at ground level
+accept .*DLWRF_Sfc.*
+# upward surface latent heat flux (for VHFR FVCOM)
+accept .*LHTFL_Sfc.*
+# air temperature at 2m elevation
+accept .*TMP_AGL-2m.*
+# specific humidity at 2m elevation
+accept .*SPFH_AGL-2m.*
+# relative humidity at 2m elevation (for VHFR FVCOM)
+accept .*RH_AGL-2m.*
+# accumulated precipitation at ground level
+accept .*APCP_Sfc.*
+# precipitation rate at ground level (for VHFR FVCOM)
+accept .*PRATE_Sfc.*
+# atmospheric pressure at mean sea level
+accept .*PRMSL_MSL.*

--- a/sarracenia/hrdps-continental-hpfx.conf
+++ b/sarracenia/hrdps-continental-hpfx.conf
@@ -1,7 +1,7 @@
 broker amqps://hpfx.collab.science.gc.ca/
 queue_name q_anonymous.sr_subscribe.hrdps-continental-hpfx.UBC.SalishSeaCast
 instances 1
-expire 3h
+expire 6h
 
 subtopic *.WXO-DD.model_hrdps.continental.2.5km.#
 directory /SalishSeaCast/datamart/hrdps-continental/

--- a/sarracenia/hrdps-continental-hpfx.conf
+++ b/sarracenia/hrdps-continental-hpfx.conf
@@ -1,6 +1,6 @@
 broker amqps://hpfx.collab.science.gc.ca/
 queue_name q_anonymous.sr_subscribe.hrdps-continental-hpfx.UBC.SalishSeaCast
-instances 2
+instances 1
 expire 3h
 
 subtopic *.WXO-DD.model_hrdps.continental.2.5km.#

--- a/sarracenia/hrdps-continental-hpfx.conf
+++ b/sarracenia/hrdps-continental-hpfx.conf
@@ -5,7 +5,7 @@ expire 3h
 
 subtopic *.WXO-DD.model_hrdps.continental.2.5km.#
 directory /SalishSeaCast/datamart/hrdps-continental/
-# mirror the datamart directory structure but drop the 1st 4 path elements
+# mirror the datamart directory structure but drop the 1st 6 path elements
 # so that our mirror starts with forecast number (00/, 06/, 12/, or 18/)
 mirror true
 strip 6

--- a/sarracenia/hydrometric-dd-weather.conf
+++ b/sarracenia/hydrometric-dd-weather.conf
@@ -1,4 +1,8 @@
 broker amqps://anonymous@dd.weather.gc.ca
+queue_name q_anonymous.sr_subscribe.hydrometric-dd-weather.UBC.SalishSeaCast
+instances 1
+expire 1h
+
 subtopic hydrometric.csv.BC.hourly
 directory /SalishSeaCast/datamart/hydrometric
 overwrite true


### PR DESCRIPTION
This was done as an _ad hoc_ change on 25-Apr-2023 to avoid disruption due to expected hpfx server maintenance.
However, the missing file messages and duplicated files issues in HRDPS downloads
that started with the change to the continental rotated lat-lon grid in Feb-2023
disappeared with the change to dd.weather.gc.ca.
So, this PR makes the change official.