### PR TITLE
Add make_v202111_runoff_file worker

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -47,7 +47,7 @@ jobs:
           pytest --cov=$GITHUB_WORKSPACE --cov-report=xml
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -19,13 +19,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@e2b397b12d0a38069451664382b769c9456e3d6d
+        uses: mamba-org/setup-micromamba@5d5dbebd87f7b9358c403c7a66651fa92b310105
         with:
            environment-file: envs/environment-test.yaml
            environment-name: salishsea-nowcast-test
-           cache-env: true
-           extra-specs: |
-             python=${{ matrix.python-version }}
+           # environment caching does not play nicely with --editable installed packages
+           cache-environment: false
+           cache-downloads: true
+           # persist downloads cache for 1 day
+           cache-downloads-key: downloads-${{ steps.date.outputs.date }}
+           create-args: >-
+             python=${{ inputs.python-version }}
 
       - name: Install editable-node dependency packages
         shell: bash -l {0}

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -1272,6 +1272,12 @@ message registry:
       failure: rivers forcing files preparation failed
       crash: make_runoff_file worker crashed
 
+    make_v202111_runoff_file:
+      checklist key: v202111 rivers forcing
+      success: v202111 rivers forcing ready
+      failure: v202111 rivers forcing files preparation failed
+      crash: make_v202111_runoff_file worker crashed
+
     collect_NeahBay_ssh:
       checklist key: Neah Bay ssh data
       success 00: 00Z Neah Bay ssh data collection succeeded

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -179,6 +179,7 @@ rivers:
   # TODO: collapse to single item for v202111; b201702 key not required
   prop_dict modules:
     b201702: salishsea_tools.river_201702
+    b202108: salishsea_tools.river_202108
   turbidity:
     # File containing hourly real-time Fraser River water quality buoy turbidity data
     ECget Fraser turbidity: /results/observations/ECCC/fraser_buoy.csv

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -175,6 +175,7 @@ rivers:
   # TODO: collapse to single item for v202111; b201702 key not required
   file templates:
     b201702:  "R201702DFraCElse_{:y%Ym%md%d}.nc"
+    b202108:  "R202108Dailies_{:y%Ym%md%d}.nc"
   # Module containing dictionary of the proportions that each river occupies in its watershed
   # TODO: collapse to single item for v202111; b201702 key not required
   prop_dict modules:

--- a/docs/workers.rst
+++ b/docs/workers.rst
@@ -113,6 +113,13 @@ Workers
     :members: main
 
 
+:kbd:`make_v202111_runoff_file`
+-------------------------------
+
+.. automodule:: nowcast.workers.make_v202111_runoff_file
+    :members: main
+
+
 .. _CollectNeahBaySshWorker:
 
 :kbd:`collect_NeahBay_ssh`

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -157,7 +157,7 @@ pytz==2023.3
 PyYAML==6.0
 pyzmq==25.0.2
 rasterio==1.3.6
-requests==2.28.2
+requests==2.31.0
 requests-file==1.5.1
 requests-toolbelt==0.10.1
 retrying==1.3.3

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -257,6 +257,9 @@ def after_collect_river_data(msg, config, checklist):
     next_workers = {"crash": [], "failure": [], "success": []}
     if msg.type == "success" and checklist["river data"]["river name"] == "Fraser":
         next_workers["success"].append(NextWorker("nowcast.workers.make_runoff_file"))
+        next_workers["success"].append(
+            NextWorker("nowcast.workers.make_v202111_runoff_file")
+        )
     return next_workers[msg.type]
 
 

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -282,6 +282,28 @@ def after_make_runoff_file(msg, config, checklist):
     return next_workers[msg.type]
 
 
+def after_make_v202111_runoff_file(msg, config, checklist):
+    """Calculate the list of workers to launch after the make_v202111_runoff_file
+    worker ends.
+
+    :arg msg: Nowcast system message.
+    :type msg: :py:class:`nemo_nowcast.message.Message`
+
+    :arg config: :py:class:`dict`-like object that holds the nowcast system
+                 configuration that is loaded from the system configuration
+                 file.
+    :type config: :py:class:`nemo_nowcast.config.Config`
+
+    :arg dict checklist: System checklist: data structure containing the
+                         present state of the nowcast system.
+
+    :returns: Worker(s) to launch next
+    :rtype: list
+    """
+    next_workers = {"crash": [], "failure": [], "success": []}
+    return next_workers[msg.type]
+
+
 def after_collect_NeahBay_ssh(msg, config, checklist):
     """Calculate the list of workers to launch after the collect_NeahBay_ssh worker
     ends.

--- a/nowcast/workers/make_v202111_runoff_file.py
+++ b/nowcast/workers/make_v202111_runoff_file.py
@@ -1,0 +1,71 @@
+#  Copyright 2013 – present by the SalishSeaCast Project contributors
+#  and The University of British Columbia
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""SalishSeaCast worker that calculates NEMO runoff forcing file from day-averaged river
+discharge observations (lagged by 1 day) from representative gauged rivers in all watersheds
+and fits developed by Susan Allen.
+Missing river discharge observations are handled by a scheme of persistence or scaling of
+a nearby gauged river, depending on time span of missing observations.
+"""
+import logging
+
+import arrow
+from nemo_nowcast import NowcastWorker
+
+NAME = "make_v202111_runoff_file"
+logger = logging.getLogger(NAME)
+
+
+def main():
+    """For command-line usage see:
+
+    :command:`python -m nowcast.workers.make_v202111_runoff_file --help`
+    """
+    worker = NowcastWorker(NAME, description=__doc__)
+    worker.init_cli()
+    worker.cli.add_date_option(
+        "--data-date",
+        default=arrow.now().floor("day"),
+        help="Date to make runoff file for.",
+    )
+    worker.run(make_v202111_runoff_file, success, failure)
+    return worker
+
+
+def success(parsed_args):
+    logger.info(
+        f"{parsed_args.data_date.format('YYYY-MM-DD')} runoff file creation completed"
+    )
+    return "success"
+
+
+def failure(parsed_args):
+    logger.critical(
+        f"{parsed_args.data_date.format('YYYY-MM-DD')} runoff file creation failed"
+    )
+    return "failure"
+
+
+def make_v202111_runoff_file(parsed_args, config, *args):
+    checklist = {}
+
+    return checklist
+
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/nowcast/workers/make_v202111_runoff_file.py
+++ b/nowcast/workers/make_v202111_runoff_file.py
@@ -31,6 +31,36 @@ NAME = "make_v202111_runoff_file"
 logger = logging.getLogger(NAME)
 
 
+# TODO: Ideally these module-level variables should be in the main or a supplemental config file.
+#       They should also be in a better data structure.
+#       We're leaving them here for now because it's "good enough",
+#       and the priority is getting v202111 into production.
+watershed_names = [
+    "bute",
+    "evi_n",
+    "jervis",
+    "evi_s",
+    "howe",
+    "jdf",
+    "skagit",
+    "puget",
+    "toba",
+    "fraser",
+]
+rivers_for_watershed = {
+    "bute": {"primary": "Homathko_Mouth", "secondary": None},
+    "evi_n": {"primary": "Salmon_Sayward", "secondary": None},
+    "jervis": {"primary": "Clowhom_ClowhomLake", "secondary": "RobertsCreek"},
+    "evi_s": {"primary": "Englishman", "secondary": None},
+    "howe": {"primary": "Squamish_Brackendale", "secondary": None},
+    "jdf": {"primary": "SanJuan_PortRenfrew", "secondary": None},
+    "skagit": {"primary": "Skagit_MountVernon", "secondary": "Snohomish_Monroe"},
+    "puget": {"primary": "Nisqually_McKenna", "secondary": "Greenwater_Greenwater"},
+    "toba": {"primary": "Homathko_Mouth", "secondary": "Theodosia"},
+    "fraser": {"primary": "Fraser", "secondary": "Nicomekl_Langley"},
+}
+
+
 def main():
     """For command-line usage see:
 
@@ -62,9 +92,72 @@ def failure(parsed_args):
 
 
 def make_v202111_runoff_file(parsed_args, config, *args):
+    obs_date = parsed_args.data_date
+    logger.info(
+        f"calculating NEMO runoff forcing for 202108 bathymetry for {obs_date.format('YYYY-MM-DD')}"
+    )
+    flows = _calc_watershed_flows(obs_date, config)
+
     checklist = {}
 
     return checklist
+
+
+def _calc_watershed_flows(obs_date, config):
+    """
+    :param :py:class:`arrow.Arrow` obs_date:
+    :param dict config:
+
+    :rtype: dict
+    """
+
+    flows = {}
+    for watershed_name in watershed_names:
+        if watershed_name == "fraser":
+            flows["fraser"], flows["non_fraser"] = _do_fraser(obs_date, config)
+        else:
+            if rivers_for_watershed[watershed_name]["secondary"] is None:
+                logger.debug(f"no secondary river for {watershed_name} watershed")
+            flows[watershed_name] = _do_a_river_pair(
+                watershed_name,
+                obs_date,
+                rivers_for_watershed[watershed_name]["primary"],
+                config,
+                rivers_for_watershed[watershed_name]["secondary"],
+            )
+        logger.debug(
+            f"{watershed_name} watershed flow: {flows[watershed_name]:.3f} m3 s-1"
+        )
+    return flows
+
+
+def _do_fraser(obs_date, config):
+    """
+    :param :py:class:`arrow.Arrow` obs_date:
+    :param dict config:
+
+    :rtype: tuple
+    """
+    pass
+
+
+def _do_a_river_pair(
+    watershed_name,
+    obs_date,
+    primary_river_name,
+    config,
+    secondary_river_name=None,
+):
+    """
+    :param str watershed_name:
+    :param :py:class:`arrow.Arrow` obs_date:
+    :param str primary_river_name:
+    :param dict config:
+    :param str or :py:class:`NoneType` secondary_river_name:
+
+    :rtype: float
+    """
+    pass
 
 
 if __name__ == "__main__":

--- a/nowcast/workers/make_v202111_runoff_file.py
+++ b/nowcast/workers/make_v202111_runoff_file.py
@@ -143,7 +143,7 @@ def main():
     worker.init_cli()
     worker.cli.add_date_option(
         "--data-date",
-        default=arrow.now().floor("day"),
+        default=arrow.now().floor("day").shift(days=-1),
         help="Date to make runoff file for.",
     )
     worker.run(make_v202111_runoff_file, success, failure)

--- a/nowcast/workers/make_v202111_runoff_file.py
+++ b/nowcast/workers/make_v202111_runoff_file.py
@@ -192,13 +192,39 @@ def _do_a_river_pair(
 
     :rtype: float
     """
-    pass
+    primary_river = _read_river(primary_river_name, "primary", config)
+    primary_flow = _get_river_flow(primary_river_name, primary_river, obs_date, config)
+    watershed_flow = primary_flow * watershed_from_river[watershed_name]["primary"]
+    if secondary_river_name is None:
+        return watershed_flow
+
+    secondary_river = (
+        _read_river_Theodosia(config)
+        if secondary_river_name == "Theodosia"
+        else _read_river(secondary_river_name, "secondary", config)
+    )
+    secondary_flow = _get_river_flow(
+        secondary_river_name, secondary_river, obs_date, config
+    )
+    watershed_flow += secondary_flow * watershed_from_river[watershed_name]["secondary"]
+    return watershed_flow
 
 
 def _read_river(river_name, ps, config):
     """
     :param str river_name:
     :param str ps: "primary" or "secondary"
+    :param dict config:
+
+    :rtype: :py:class:`pandas.Dataframe`
+    """
+    pass
+
+
+def _read_river_Theodosia(config):
+    """Read daily average discharge observations for 3 parts of Theodosia River
+    from river flow files, and combine them to get total.
+
     :param dict config:
 
     :rtype: :py:class:`pandas.Dataframe`

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -477,9 +477,30 @@ class TestAfterCollectRiverData:
             Message("collect_river_data", "success"), config, checklist
         )
         expected = NextWorker("nowcast.workers.make_runoff_file", [], host="localhost")
-        assert expected in workers
+        assert workers[0] == expected
+
+    def test_success_Fraser_launch_make_v202111_runoff_file(
+        self, config, checklist, monkeypatch
+    ):
+        monkeypatch.setitem(checklist, "river data", {"river name": "Fraser"})
+        workers = next_workers.after_collect_river_data(
+            Message("collect_river_data", "success"), config, checklist
+        )
+        expected = NextWorker(
+            "nowcast.workers.make_v202111_runoff_file", [], host="localhost"
+        )
+        assert workers[1] == expected
 
     def test_success_Englishman_no_launch_make_runoff_file(
+        self, config, checklist, monkeypatch
+    ):
+        monkeypatch.setitem(checklist, "river data", {"river name": "Englishman"})
+        workers = next_workers.after_collect_river_data(
+            Message("collect_river_data", "success"), config, checklist
+        )
+        assert workers == []
+
+    def test_success_Englishman_no_launch_make_v202111_runoff_file(
         self, config, checklist, monkeypatch
     ):
         monkeypatch.setitem(checklist, "river data", {"river name": "Englishman"})

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -500,6 +500,17 @@ class TestAfterMakeRunoffFile:
         assert workers == []
 
 
+class TestAfterMakeV202111RunoffFile:
+    """Unit tests for the after_make_v202111_runoff_file function."""
+
+    @pytest.mark.parametrize("msg_type", ["crash", "failure", "success"])
+    def test_no_next_worker_msg_types(self, msg_type, config, checklist):
+        workers = next_workers.after_make_v202111_runoff_file(
+            Message("make_v202111_runoff_file", msg_type), config, checklist
+        )
+        assert workers == []
+
+
 class TestAfterCollectNeahBaySsh:
     """Unit tests for the after_collect_NeahBay_ssh function."""
 

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -93,7 +93,8 @@ class TestMain:
         assert worker.cli.parser._actions[3].dest == "data_date"
         expected = nemo_nowcast.cli.CommandLineInterface.arrow_date
         assert worker.cli.parser._actions[3].type == expected
-        assert worker.cli.parser._actions[3].default == arrow.now().floor("day")
+        expected = arrow.now().floor("day").shift(days=-1)
+        assert worker.cli.parser._actions[3].default == expected
         assert worker.cli.parser._actions[3].help
 
 

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -98,6 +98,51 @@ class TestConfig:
         ]
 
 
+class TestModuleVariables:
+    """
+    Unit tests for config-type information that is stored in module variables in the
+    make_v202111_runoff_file worker.
+    """
+
+    def test_watershed_names(self):
+        expected = [
+            "bute",
+            "evi_n",
+            "jervis",
+            "evi_s",
+            "howe",
+            "jdf",
+            "skagit",
+            "puget",
+            "toba",
+            "fraser",
+        ]
+
+        assert make_v202111_runoff_file.watershed_names == expected
+
+    def test_rivers_for_watershed(self):
+        expected = {
+            "bute": {"primary": "Homathko_Mouth", "secondary": None},
+            "evi_n": {"primary": "Salmon_Sayward", "secondary": None},
+            "jervis": {"primary": "Clowhom_ClowhomLake", "secondary": "RobertsCreek"},
+            "evi_s": {"primary": "Englishman", "secondary": None},
+            "howe": {"primary": "Squamish_Brackendale", "secondary": None},
+            "jdf": {"primary": "SanJuan_PortRenfrew", "secondary": None},
+            "skagit": {
+                "primary": "Skagit_MountVernon",
+                "secondary": "Snohomish_Monroe",
+            },
+            "puget": {
+                "primary": "Nisqually_McKenna",
+                "secondary": "Greenwater_Greenwater",
+            },
+            "toba": {"primary": "Homathko_Mouth", "secondary": "Theodosia"},
+            "fraser": {"primary": "Fraser", "secondary": "Nicomekl_Langley"},
+        }
+
+        assert make_v202111_runoff_file.rivers_for_watershed == expected
+
+
 class TestSuccess:
     """Unit test for success() function."""
 
@@ -129,7 +174,19 @@ class TestFailure:
 class TestMakeV202111RunoffFile:
     """Unit tests for make_v202111_runoff_file() function."""
 
-    def test_checklist(self, config, caplog):
+    @staticmethod
+    @pytest.fixture
+    def mock_calc_watershed_flows(monkeypatch):
+        def _mock_calc_watershed_flows(obs_date, config):
+            pass
+
+        monkeypatch.setattr(
+            make_v202111_runoff_file,
+            "_calc_watershed_flows",
+            _mock_calc_watershed_flows,
+        )
+
+    def test_checklist(self, mock_calc_watershed_flows, config, caplog):
         parsed_args = SimpleNamespace(data_date=arrow.get("2023-05-19"))
 
         checklist = make_v202111_runoff_file.make_v202111_runoff_file(
@@ -137,3 +194,103 @@ class TestMakeV202111RunoffFile:
         )
 
         assert checklist == {}
+
+    def test_log_messages(self, mock_calc_watershed_flows, config, caplog):
+        parsed_args = SimpleNamespace(data_date=arrow.get("2023-05-26"))
+        caplog.set_level(logging.DEBUG)
+
+        make_v202111_runoff_file.make_v202111_runoff_file(parsed_args, config)
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = (
+            "calculating NEMO runoff forcing for 202108 bathymetry for 2023-05-26"
+        )
+        assert caplog.messages[0] == expected
+
+
+class TestCalcWatershedFlows:
+    """Unit test for _calc_watershed_flows()."""
+
+    @staticmethod
+    @pytest.fixture
+    def mock_do_a_river_pair(monkeypatch):
+        mock_watershed_flows = [
+            ("bute", 83.3223456),
+            ("evi_n", 354.56739384),
+            ("jervis", 118.43897380000001),
+            ("evi_s", 175.51416120000002),
+            ("howe", 84.56446136),
+            ("jdf", 380.26035625),
+            ("skagit", 519.6378946),
+            ("puget", 442.39027494999993),
+            ("toba", 56.474250732),
+        ]
+
+        def _mock_do_a_river_pair(
+            watershed_name,
+            obs_date,
+            primary_river_name,
+            config,
+            secondary_river_name=None,
+        ):
+            return mock_watershed_flows.pop(0)[1]
+
+        monkeypatch.setattr(
+            make_v202111_runoff_file, "_do_a_river_pair", _mock_do_a_river_pair
+        )
+
+    @staticmethod
+    @pytest.fixture
+    def mock_do_fraser(monkeypatch):
+        def _mock_do_fraser(obs_date, config):
+            return 1094.5609129386, 63.9781423614
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_do_fraser", _mock_do_fraser)
+
+    def test_calc_watershed_flows(
+        self, mock_do_a_river_pair, mock_do_fraser, config, monkeypatch
+    ):
+        obs_date = arrow.get("2023-02-19")
+
+        flows = make_v202111_runoff_file._calc_watershed_flows(obs_date, config)
+
+        expected = {
+            "bute": 83.3223456,
+            "evi_n": 354.56739384,
+            "jervis": 118.43897380000001,
+            "evi_s": 175.51416120000002,
+            "howe": 84.56446136,
+            "jdf": 380.26035625,
+            "skagit": 519.6378946,
+            "puget": 442.39027494999993,
+            "toba": 56.474250732,
+            "fraser": 1094.5609129386,
+        }
+        for name in make_v202111_runoff_file.watershed_names:
+            assert flows[name] == pytest.approx(expected[name])
+        assert flows["non_fraser"] == pytest.approx(63.9781423614)
+
+    def test_log_messages(
+        self, mock_do_a_river_pair, mock_do_fraser, config, caplog, monkeypatch
+    ):
+        obs_date = arrow.get("2023-02-26")
+        caplog.set_level(logging.DEBUG)
+
+        make_v202111_runoff_file._calc_watershed_flows(obs_date, config)
+
+        assert caplog.records[0].levelname == "DEBUG"
+        assert caplog.messages[0] == "no secondary river for bute watershed"
+        assert caplog.messages[1] == "bute watershed flow: 83.322 m3 s-1"
+        assert caplog.messages[2] == "no secondary river for evi_n watershed"
+        assert caplog.messages[3] == "evi_n watershed flow: 354.567 m3 s-1"
+        assert caplog.messages[4] == "jervis watershed flow: 118.439 m3 s-1"
+        assert caplog.messages[5] == "no secondary river for evi_s watershed"
+        assert caplog.messages[6] == "evi_s watershed flow: 175.514 m3 s-1"
+        assert caplog.messages[7] == "no secondary river for howe watershed"
+        assert caplog.messages[8] == "howe watershed flow: 84.564 m3 s-1"
+        assert caplog.messages[9] == "no secondary river for jdf watershed"
+        assert caplog.messages[10] == "jdf watershed flow: 380.260 m3 s-1"
+        assert caplog.messages[11] == "skagit watershed flow: 519.638 m3 s-1"
+        assert caplog.messages[12] == "puget watershed flow: 442.390 m3 s-1"
+        assert caplog.messages[13] == "toba watershed flow: 56.474 m3 s-1"
+        assert caplog.messages[14] == "fraser watershed flow: 1094.561 m3 s-1"

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -476,11 +476,225 @@ class TestDoFraser:
         assert secondary_flux == pytest.approx(63.978142)
 
 
+class TestDoARiverPair:
+    """Unit tests for _do_a_river_pair()."""
+
+    def test_primary_river_only_no_patch_required(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config_):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-13"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [4.444965e01],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        watershed_name = "bute"
+        obs_date = arrow.get("2023-02-13")
+        primary_river_name = "Homathko_Mouth"
+        secondary_river_name = None
+
+        watershed_flux = make_v202111_runoff_file._do_a_river_pair(
+            watershed_name, obs_date, primary_river_name, config, secondary_river_name
+        )
+
+        assert watershed_flux == pytest.approx(89.566045)
+
+    def test_primary_river_patched(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config_):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-17"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [4.329455e01],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        def mock_patch_missing_obs(river_name, river_flow, obs_date, config):
+            mock_flux = 5.338837e01
+            return mock_flux
+
+        monkeypatch.setattr(
+            make_v202111_runoff_file, "_patch_missing_obs", mock_patch_missing_obs
+        )
+
+        watershed_name = "bute"
+        obs_date = arrow.get("2023-02-18")
+        primary_river_name = "Homathko_Mouth"
+        secondary_river_name = None
+
+        watershed_flux = make_v202111_runoff_file._do_a_river_pair(
+            watershed_name, obs_date, primary_river_name, config, secondary_river_name
+        )
+
+        assert watershed_flux == pytest.approx(107.577565)
+
+    def test_primary_and_secondary_rivers_no_patches(self, config, monkeypatch):
+        mock_dataframes = [
+            # Primary river
+            pandas.DataFrame(
+                # Clowhom_ClowhomLake
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-13"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [5.549688e00],
+                },
+            ),
+            # Secondary river
+            pandas.DataFrame(
+                # RobertsCreek
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-13"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Secondary River Flow": [9.963607e-01],
+                },
+            ),
+        ]
+
+        def mock_read_river(river_name, ps, config_):
+            return mock_dataframes.pop(0)
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        watershed_name = "jervis"
+        obs_date = arrow.get("2023-02-13")
+        primary_river_name = "Clowhom_ClowhomLake"
+        secondary_river_name = "RobertsCreek"
+
+        watershed_flux = make_v202111_runoff_file._do_a_river_pair(
+            watershed_name, obs_date, primary_river_name, config, secondary_river_name
+        )
+
+        assert watershed_flux == pytest.approx(188.682157)
+
+    def test_secondary_Theodosia_no_patches(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config_):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-18"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [4.175144e01],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        def mock_read_river_Theodosia(config_):
+            return pandas.DataFrame(
+                # Theodosia
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-18"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Secondary River Flow": [5.39236e0],
+                },
+            )
+
+        monkeypatch.setattr(
+            make_v202111_runoff_file, "_read_river_Theodosia", mock_read_river_Theodosia
+        )
+
+        watershed_name = "toba"
+        obs_date = arrow.get("2023-02-18")
+        primary_river_name = "Homathko_Mouth"
+        secondary_river_name = "Theodosia"
+
+        watershed_flux = make_v202111_runoff_file._do_a_river_pair(
+            watershed_name, obs_date, primary_river_name, config, secondary_river_name
+        )
+
+        assert watershed_flux == pytest.approx(97.67179087)
+
+    def test_secondary_river_patched(self, config, monkeypatch):
+        mock_dataframes = [
+            # Primary river
+            pandas.DataFrame(
+                # Clowhom_ClowhomLake
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-18"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [3.391116e00],
+                },
+            ),
+            # Secondary river
+            pandas.DataFrame(
+                # RobertsCreek
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-17"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Secondary River Flow": [6.383818e-01],
+                },
+            ),
+        ]
+
+        def mock_read_river(river_name, ps, config_):
+            return mock_dataframes.pop(0)
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        def mock_patch_missing_obs(river_name, river_flow, obs_date, config):
+            mock_flux = 8.285429e-01
+            return mock_flux
+
+        monkeypatch.setattr(
+            make_v202111_runoff_file, "_patch_missing_obs", mock_patch_missing_obs
+        )
+
+        watershed_name = "jervis"
+        obs_date = arrow.get("2023-02-13")
+        primary_river_name = "Clowhom_ClowhomLake"
+        secondary_river_name = "RobertsCreek"
+
+        watershed_flux = make_v202111_runoff_file._do_a_river_pair(
+            watershed_name, obs_date, primary_river_name, config, secondary_river_name
+        )
+
+        assert watershed_flux == pytest.approx(123.54403)
+
+
 @pytest.mark.parametrize(
     "flow_col_label", ("Primary River Flow", "Secondary River Flow")
 )
 class TestGetRiverFlow:
-    """Unit tests for daily_river_flows._get_river_flow()."""
+    """Unit tests for _get_river_flow()."""
 
     def test_get_river_flow(self, flow_col_label, config):
         river_name = "SanJuan_PortRenfrew"

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -1273,3 +1273,376 @@ class TestPatchMissingObs:
         )
 
         assert flux == pytest.approx(5.195243e01)
+
+
+class TestPatchFitting:
+    """Unit tests for make_v202111_runoff_file._patch_fitting()."""
+
+    def test_1_day_missing_patch_successful(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-06"),
+                        pandas.to_datetime("2023-02-07"),
+                        pandas.to_datetime("2023-02-08"),
+                        pandas.to_datetime("2023-02-09"),
+                        pandas.to_datetime("2023-02-10"),
+                        pandas.to_datetime("2023-02-11"),
+                        pandas.to_datetime("2023-02-12"),
+                        pandas.to_datetime("2023-02-13"),
+                        pandas.to_datetime("2023-02-14"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [
+                        3.690729e01,
+                        6.113299e01,
+                        5.083090e01,
+                        4.158090e01,
+                        4.387431e01,
+                        4.237986e01,
+                        4.243368e01,
+                        4.444965e01,
+                        3.756528e01,
+                    ],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        river_flow = pandas.DataFrame(
+            # Squamish_Brackendale
+            index=pandas.Index(
+                data=[
+                    pandas.to_datetime("2023-02-06"),
+                    pandas.to_datetime("2023-02-07"),
+                    pandas.to_datetime("2023-02-08"),
+                    pandas.to_datetime("2023-02-09"),
+                    pandas.to_datetime("2023-02-10"),
+                    pandas.to_datetime("2023-02-11"),
+                    pandas.to_datetime("2023-02-12"),
+                    pandas.to_datetime("2023-02-13"),
+                ],
+                name="date",
+            ),
+            data={
+                "Primary River Flow": [
+                    4.181135e01,
+                    9.415799e01,
+                    8.465509e01,
+                    6.185860e01,
+                    6.616285e01,
+                    6.533544e01,
+                    5.635754e01,
+                    8.004896e01,
+                ],
+            },
+        )
+        fit_from_river_name = "Homathko_Mouth"
+        obs_date = arrow.get("2023-02-14")
+        gap_length = 1
+
+        flux = make_v202111_runoff_file._patch_fitting(
+            river_flow, fit_from_river_name, obs_date, gap_length, config
+        )
+
+        assert flux == pytest.approx(54.759385)
+
+    def test_3_days_missing_patch_successful(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-04"),
+                        pandas.to_datetime("2023-02-05"),
+                        pandas.to_datetime("2023-02-06"),
+                        pandas.to_datetime("2023-02-07"),
+                        pandas.to_datetime("2023-02-08"),
+                        pandas.to_datetime("2023-02-09"),
+                        pandas.to_datetime("2023-02-10"),
+                        pandas.to_datetime("2023-02-11"),
+                        pandas.to_datetime("2023-02-12"),
+                        pandas.to_datetime("2023-02-13"),
+                        pandas.to_datetime("2023-02-14"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [
+                        3.107431e01,
+                        3.446285e01,
+                        3.690729e01,
+                        6.113299e01,
+                        5.083090e01,
+                        4.158090e01,
+                        4.387431e01,
+                        4.237986e01,
+                        4.243368e01,
+                        4.444965e01,
+                        3.756528e01,
+                    ],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        river_flow = pandas.DataFrame(
+            # Squamish_Brackendale
+            index=pandas.Index(
+                data=[
+                    pandas.to_datetime("2023-02-04"),
+                    pandas.to_datetime("2023-02-05"),
+                    pandas.to_datetime("2023-02-06"),
+                    pandas.to_datetime("2023-02-07"),
+                    pandas.to_datetime("2023-02-08"),
+                    pandas.to_datetime("2023-02-09"),
+                    pandas.to_datetime("2023-02-10"),
+                    pandas.to_datetime("2023-02-11"),
+                ],
+                name="date",
+            ),
+            data={
+                "Primary River Flow": [
+                    4.714132e01,
+                    4.199236e01,
+                    4.181135e01,
+                    9.415799e01,
+                    8.465509e01,
+                    6.185860e01,
+                    6.616285e01,
+                    6.533544e01,
+                ],
+            },
+        )
+        fit_from_river_name = "Homathko_Mouth"
+        obs_date = arrow.get("2023-02-14")
+        gap_length = 3
+
+        flux = make_v202111_runoff_file._patch_fitting(
+            river_flow, fit_from_river_name, obs_date, gap_length, config
+        )
+
+        assert flux == pytest.approx(54.038875)
+
+    def test_gap_in_river_to_patch_failure(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-06"),
+                        pandas.to_datetime("2023-02-07"),
+                        pandas.to_datetime("2023-02-08"),
+                        pandas.to_datetime("2023-02-09"),
+                        pandas.to_datetime("2023-02-10"),
+                        pandas.to_datetime("2023-02-11"),
+                        pandas.to_datetime("2023-02-12"),
+                        pandas.to_datetime("2023-02-13"),
+                        pandas.to_datetime("2023-02-14"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [
+                        3.690729e01,
+                        6.113299e01,
+                        5.083090e01,
+                        4.158090e01,
+                        4.387431e01,
+                        4.237986e01,
+                        4.243368e01,
+                        4.444965e01,
+                        3.756528e01,
+                    ],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        river_flow = pandas.DataFrame(
+            # Squamish_Brackendale
+            index=pandas.Index(
+                data=[
+                    pandas.to_datetime("2023-02-06"),
+                    pandas.to_datetime("2023-02-07"),
+                    pandas.to_datetime("2023-02-08"),
+                    # missing day
+                    pandas.to_datetime("2023-02-10"),
+                    pandas.to_datetime("2023-02-11"),
+                    pandas.to_datetime("2023-02-12"),
+                    pandas.to_datetime("2023-02-13"),
+                ],
+                name="date",
+            ),
+            data={
+                "Primary River Flow": [
+                    4.181135e01,
+                    9.415799e01,
+                    8.465509e01,
+                    # missing day
+                    6.616285e01,
+                    6.533544e01,
+                    5.635754e01,
+                    8.004896e01,
+                ],
+            },
+        )
+        fit_from_river_name = "Homathko_Mouth"
+        obs_date = arrow.get("2023-02-14")
+        gap_length = 1
+
+        flux = make_v202111_runoff_file._patch_fitting(
+            river_flow, fit_from_river_name, obs_date, gap_length, config
+        )
+
+        assert numpy.isnan(flux)
+
+    def test_gap_in_river_to_fit_from_failure(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-06"),
+                        pandas.to_datetime("2023-02-07"),
+                        pandas.to_datetime("2023-02-08"),
+                        # missing day
+                        pandas.to_datetime("2023-02-10"),
+                        pandas.to_datetime("2023-02-11"),
+                        pandas.to_datetime("2023-02-12"),
+                        pandas.to_datetime("2023-02-13"),
+                        pandas.to_datetime("2023-02-14"),
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [
+                        3.690729e01,
+                        6.113299e01,
+                        5.083090e01,
+                        # missing day
+                        4.387431e01,
+                        4.237986e01,
+                        4.243368e01,
+                        4.444965e01,
+                        3.756528e01,
+                    ],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        river_flow = pandas.DataFrame(
+            # Squamish_Brackendale
+            index=pandas.Index(
+                data=[
+                    pandas.to_datetime("2023-02-06"),
+                    pandas.to_datetime("2023-02-07"),
+                    pandas.to_datetime("2023-02-08"),
+                    pandas.to_datetime("2023-02-09"),
+                    pandas.to_datetime("2023-02-10"),
+                    pandas.to_datetime("2023-02-11"),
+                    pandas.to_datetime("2023-02-12"),
+                    pandas.to_datetime("2023-02-13"),
+                ],
+                name="date",
+            ),
+            data={
+                "Primary River Flow": [
+                    4.181135e01,
+                    9.415799e01,
+                    8.465509e01,
+                    6.185860e01,
+                    6.616285e01,
+                    6.533544e01,
+                    5.635754e01,
+                    8.004896e01,
+                ],
+            },
+        )
+        fit_from_river_name = "Homathko_Mouth"
+        obs_date = arrow.get("2023-02-14")
+        gap_length = 1
+
+        flux = make_v202111_runoff_file._patch_fitting(
+            river_flow, fit_from_river_name, obs_date, gap_length, config
+        )
+
+        assert numpy.isnan(flux)
+
+    def test_river_to_patch_from_missing_obs_date_failure(self, config, monkeypatch):
+        def mock_read_river(river_name, ps, config):
+            return pandas.DataFrame(
+                # Homathko_Mouth
+                index=pandas.Index(
+                    data=[
+                        pandas.to_datetime("2023-02-06"),
+                        pandas.to_datetime("2023-02-07"),
+                        pandas.to_datetime("2023-02-08"),
+                        pandas.to_datetime("2023-02-09"),
+                        pandas.to_datetime("2023-02-10"),
+                        pandas.to_datetime("2023-02-11"),
+                        pandas.to_datetime("2023-02-12"),
+                        pandas.to_datetime("2023-02-13"),
+                        # missing obs date
+                    ],
+                    name="date",
+                ),
+                data={
+                    "Primary River Flow": [
+                        3.690729e01,
+                        6.113299e01,
+                        5.083090e01,
+                        4.158090e01,
+                        4.387431e01,
+                        4.237986e01,
+                        4.243368e01,
+                        4.444965e01,
+                        # missing obs date value
+                    ],
+                },
+            )
+
+        monkeypatch.setattr(make_v202111_runoff_file, "_read_river", mock_read_river)
+
+        river_flow = pandas.DataFrame(
+            # Squamish_Brackendale
+            index=pandas.Index(
+                data=[
+                    pandas.to_datetime("2023-02-06"),
+                    pandas.to_datetime("2023-02-07"),
+                    pandas.to_datetime("2023-02-08"),
+                    pandas.to_datetime("2023-02-09"),
+                    pandas.to_datetime("2023-02-10"),
+                    pandas.to_datetime("2023-02-11"),
+                    pandas.to_datetime("2023-02-12"),
+                    pandas.to_datetime("2023-02-13"),
+                ],
+                name="date",
+            ),
+            data={
+                "Primary River Flow": [
+                    4.181135e01,
+                    9.415799e01,
+                    8.465509e01,
+                    6.185860e01,
+                    6.616285e01,
+                    6.533544e01,
+                    5.635754e01,
+                    8.004896e01,
+                ],
+            },
+        )
+        fit_from_river_name = "Homathko_Mouth"
+        obs_date = arrow.get("2023-02-14")
+        gap_length = 1
+
+        flux = make_v202111_runoff_file._patch_fitting(
+            river_flow, fit_from_river_name, obs_date, gap_length, config
+        )
+
+        assert numpy.isnan(flux)

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -47,9 +47,13 @@ def config(base_config):
                     TheodosiaScotty: forcing/rivers/observations/Theodosia_Scotty_flow
                     TheodosiaBypass: forcing/rivers/observations/Theodosia_Bypass_flow
                     TheodosiaDiversion: forcing/rivers/observations/Theodosia_Diversion_flow
+                  prop_dict modules:
+                    b202108: salishsea_tools.river_202108
+
                 run types:
                   nowcast-green:
                     coordinates: coordinates_seagrid_SalishSea201702.nc
+
                 run:
                   enabled hosts:
                     salish-nowcast:
@@ -137,6 +141,11 @@ class TestConfig:
             "TheodosiaDiversion": "/results/forcing/rivers/observations/Theodosia_Diversion_flow",
         }
         assert SOG_river_files == expected
+
+    def test_prop_dict_modules(self, prod_config):
+        prop_dict_module = prod_config["rivers"]["prop_dict modules"]["b202108"]
+
+        assert prop_dict_module == "salishsea_tools.river_202108"
 
     def test_grid_dir(self, prod_config):
         grid_dir = Path(
@@ -1756,3 +1765,107 @@ class TestCreateRunoffArray:
         )
         # Check total runoff
         assert runoff_array.sum() == pytest.approx(22.54050399)
+
+
+class TestCalcRunoffDataset:
+    """Unit tests for make_v202111_runoff_file._calc_runoff_dataset()."""
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def runoff_array():
+        _runoff_array = numpy.zeros((898, 398))
+        _runoff_array[750:752, 123] = [0.20318864, 0.20318864]
+        return _runoff_array
+
+    def test_data_array_values(self, runoff_array, config):
+        obs_date = arrow.get("2023-05-11")
+
+        runoff_ds = make_v202111_runoff_file._calc_runoff_dataset(
+            obs_date, runoff_array, config
+        )
+
+        numpy.testing.assert_allclose(
+            runoff_ds["rorunoff"][0, 750:752, 123], [0.20318864, 0.20318864]
+        )
+
+    def test_data_array_attrs(self, runoff_array, config):
+        obs_date = arrow.get("2023-05-11")
+
+        runoff_ds = make_v202111_runoff_file._calc_runoff_dataset(
+            obs_date, runoff_array, config
+        )
+
+        assert runoff_ds["rorunoff"].attrs["standard_name"] == "runoff_flux"
+        assert runoff_ds["rorunoff"].attrs["long_name"] == "River Runoff Flux"
+        assert runoff_ds["rorunoff"].attrs["units"] == "kg m-2 s-1"
+
+    def test_coords(self, runoff_array, config):
+        obs_date = arrow.get("2023-05-11")
+
+        runoff_ds = make_v202111_runoff_file._calc_runoff_dataset(
+            obs_date, runoff_array, config
+        )
+
+        assert len(runoff_ds.coords) == 3
+        assert runoff_ds.coords["time_counter"] == pandas.to_datetime(["2023-05-11"])
+        assert all(runoff_ds.coords["y"] == numpy.arange(runoff_array.shape[0]))
+        assert all(runoff_ds.coords["x"] == numpy.arange(runoff_array.shape[1]))
+
+    def test_dims(self, runoff_array, config):
+        obs_date = arrow.get("2023-05-11")
+
+        runoff_ds = make_v202111_runoff_file._calc_runoff_dataset(
+            obs_date, runoff_array, config
+        )
+
+        assert len(runoff_ds.dims) == 3
+        assert runoff_ds.dims["time_counter"] == 1
+        assert runoff_ds.dims["y"] == runoff_array.shape[0]
+        assert runoff_ds.dims["x"] == runoff_array.shape[1]
+
+    def test_dataset_attrs(self, runoff_array, config, monkeypatch):
+        def mock_now(tz):
+            return arrow.get("2023-05-11 14:51:43-07:00")
+
+        monkeypatch.setattr(make_v202111_runoff_file.arrow, "now", mock_now)
+
+        obs_date = arrow.get("2023-05-11")
+
+        runoff_ds = make_v202111_runoff_file._calc_runoff_dataset(
+            obs_date, runoff_array, config
+        )
+
+        assert runoff_ds.attrs["creator_email"] == "sallen@eoas.ubc.ca"
+        assert runoff_ds.attrs["creator_name"] == "SalishSeaCast Project contributors"
+        assert (
+            runoff_ds.attrs["creator_url"]
+            == "https://github.com/SalishSeaCast/SalishSeaNowcast/blob/main/nowcast/workers/make_v202111_runoff_file.py"
+        )
+        assert runoff_ds.attrs["institution"] == "UBC EOAS"
+        assert (
+            runoff_ds.attrs["institution_fullname"]
+            == "Earth, Ocean & Atmospheric Sciences, University of British Columbia"
+        )
+        assert (
+            runoff_ds.attrs["title"]
+            == f"River Runoff Fluxes for {obs_date.format('YYYY-MM-DD')}"
+        )
+        assert runoff_ds.attrs["summary"] == (
+            f"Day-average river runoff fluxes calculated for {obs_date.format('YYYY-MM-DD')} "
+            f"on v202108 bathymetry. "
+            f"The runoff fluxes are calculated from day-averaged discharge (1 day lagged) observations "
+            f"from gauged rivers across the SalishSeaCast model domain using fits developed by Susan Allen."
+        )
+        assert (
+            runoff_ds.attrs["development_notebook"]
+            == "https://github.com/SalishSeaCast/tools/blob/main/I_ForcingFiles/Rivers/ProductionDailyRiverNCfile.ipynb"
+        )
+        assert (
+            runoff_ds.attrs["rivers_watersheds_proportions"]
+            == "salishsea_tools.river_202108"
+        )
+        assert runoff_ds.attrs["history"] == (
+            f"[Thu {obs_date.format('YYYY-MM-DD')} 14:51:43 -07:00] "
+            f"python3 -m nowcast.workers.make_v202111_runoff_file $NOWCAST_YAML "
+            f"--run-date {obs_date.format('YYYY-MM-DD')}"
+        )


### PR DESCRIPTION
Integrate work from PR #150 into a new worker that can be run independently of v201915 runoff file generation until we complete the production migration to v202111.