### PR TITLE
Adjust automation re: `make_v2021_runoff_file`

### DIFF
--- a/nowcast/daily_river_flows.py
+++ b/nowcast/daily_river_flows.py
@@ -425,7 +425,7 @@ def _get_area(config):
     grid_dir = Path(config["run"]["enabled hosts"]["salish-nowcast"]["grid dir"])
     if not grid_dir.exists():
         # TODO: This should be unnecessary in worker code
-        grid_dir = Path("../../grid/")
+        grid_dir = Path("../grid/")
     coords_file = grid_dir / config["run types"]["nowcast-green"]["coordinates"]
     with xr.open_dataset(coords_file, decode_times=False) as ds:
         area = ds.e1t[0] * ds.e2t[0]

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -97,6 +97,8 @@ def after_download_weather(msg, config, checklist):
                 race_condition_workers = {
                     "grib_to_netcdf",
                     "make_ssh_files",
+                    "make_runoff_file",
+                    "make_v202111_runoff_file",
                 }
                 return next_workers[msg.type], race_condition_workers
         if msg.type.endswith("2.5km 12"):
@@ -121,6 +123,8 @@ def after_download_weather(msg, config, checklist):
                 "grib_to_netcdf",
                 "make_live_ocean_files",
                 "make_ssh_files",
+                "make_runoff_file",
+                "make_v202111_runoff_file",
             }
             return next_workers[msg.type], race_condition_workers
         if msg.type.endswith("2.5km 18"):
@@ -255,16 +259,11 @@ def after_collect_river_data(msg, config, checklist):
     :rtype: list
     """
     next_workers = {"crash": [], "failure": [], "success": []}
-    if msg.type == "success" and checklist["river data"]["river name"] == "Fraser":
-        next_workers["success"].append(NextWorker("nowcast.workers.make_runoff_file"))
-        next_workers["success"].append(
-            NextWorker("nowcast.workers.make_v202111_runoff_file")
-        )
     return next_workers[msg.type]
 
 
-def after_make_runoff_file(msg, config, checklist):
-    """Calculate the list of workers to launch after the make_runoff_file
+def after_make_v202111_runoff_file(msg, config, checklist):
+    """Calculate the list of workers to launch after the make_v202111_runoff_file
     worker ends.
 
     :arg msg: Nowcast system message.
@@ -285,8 +284,8 @@ def after_make_runoff_file(msg, config, checklist):
     return next_workers[msg.type]
 
 
-def after_make_v202111_runoff_file(msg, config, checklist):
-    """Calculate the list of workers to launch after the make_v202111_runoff_file
+def after_make_runoff_file(msg, config, checklist):
+    """Calculate the list of workers to launch after the make_runoff_file
     worker ends.
 
     :arg msg: Nowcast system message.
@@ -381,6 +380,11 @@ def after_make_ssh_files(msg, config, checklist):
         "success nowcast": [],
         "success forecast2": [],
     }
+    if msg.type.startswith("success"):
+        next_workers[msg.type].append(
+            NextWorker("nowcast.workers.make_v202111_runoff_file")
+        )
+        next_workers[msg.type].append(NextWorker("nowcast.workers.make_runoff_file"))
     return next_workers[msg.type]
 
 

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -96,7 +96,6 @@ def after_download_weather(msg, config, checklist):
                 )
                 race_condition_workers = {
                     "grib_to_netcdf",
-                    "make_ssh_files",
                     "make_runoff_file",
                     "make_v202111_runoff_file",
                 }
@@ -122,7 +121,6 @@ def after_download_weather(msg, config, checklist):
             race_condition_workers = {
                 "grib_to_netcdf",
                 "make_live_ocean_files",
-                "make_ssh_files",
                 "make_runoff_file",
                 "make_v202111_runoff_file",
             }

--- a/nowcast/workers/make_runoff_file.py
+++ b/nowcast/workers/make_runoff_file.py
@@ -83,34 +83,34 @@ def make_runoff_file(parsed_args, config, *args):
     otherratio, fraserratio, nonFraser, afterHope = _fraser_climatology(config)
 
     checklist = {}
-    for bathy_type in config["rivers"]["file templates"]:
-        logger.info(f"calculating runoff forcing for bathymetry type: {bathy_type}")
-        # Get climatology
-        climatology_file = Path(config["rivers"]["monthly climatology"][bathy_type])
-        criverflow, area = _get_river_climatology(climatology_file)
-        # Interpolate to today
-        driverflow = _calculate_daily_flow(yesterday, criverflow)
-        logger.debug(f'calculated flow for {yesterday.format("YYYY-MM-DD")}')
-        # Calculate combined runoff and write file
-        directory = Path(config["rivers"]["rivers dir"])
-        filename_tmpls = config["rivers"]["file templates"][bathy_type]
-        prop_dict = importlib.import_module(
-            config["rivers"]["prop_dict modules"][bathy_type]
-        ).prop_dict
-        filepath = _combine_runoff(
-            prop_dict,
-            flow_at_hope,
-            yesterday,
-            afterHope,
-            nonFraser,
-            fraserratio,
-            otherratio,
-            driverflow,
-            area,
-            directory,
-            filename_tmpls,
-        )
-        checklist[bathy_type] = os.fspath(filepath)
+    bathy_type = "b201702"
+    logger.info(f"calculating runoff forcing for b201702 bathymetry")
+    # Get climatology
+    climatology_file = Path(config["rivers"]["monthly climatology"][bathy_type])
+    criverflow, area = _get_river_climatology(climatology_file)
+    # Interpolate to today
+    driverflow = _calculate_daily_flow(yesterday, criverflow)
+    logger.debug(f'calculated flow for {yesterday.format("YYYY-MM-DD")}')
+    # Calculate combined runoff and write file
+    directory = Path(config["rivers"]["rivers dir"])
+    filename_tmpls = config["rivers"]["file templates"][bathy_type]
+    prop_dict = importlib.import_module(
+        config["rivers"]["prop_dict modules"][bathy_type]
+    ).prop_dict
+    filepath = _combine_runoff(
+        prop_dict,
+        flow_at_hope,
+        yesterday,
+        afterHope,
+        nonFraser,
+        fraserratio,
+        otherratio,
+        driverflow,
+        area,
+        directory,
+        filename_tmpls,
+    )
+    checklist[bathy_type] = os.fspath(filepath)
     return checklist
 
 

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -235,7 +235,6 @@ class TestAfterDownloadWeather:
         assert workers == expected
         assert race_condition_workers == {
             "grib_to_netcdf",
-            "make_ssh_files",
             "make_runoff_file",
             "make_v202111_runoff_file",
         }
@@ -264,7 +263,6 @@ class TestAfterDownloadWeather:
         assert race_condition_workers == {
             "grib_to_netcdf",
             "make_live_ocean_files",
-            "make_ssh_files",
             "make_runoff_file",
             "make_v202111_runoff_file",
         }
@@ -364,7 +362,6 @@ class TestAfterCollectWeather:
         assert workers == expected
         assert race_condition_workers == {
             "grib_to_netcdf",
-            "make_ssh_files",
             "make_runoff_file",
             "make_v202111_runoff_file",
         }
@@ -396,7 +393,6 @@ class TestAfterCollectWeather:
         assert race_condition_workers == {
             "grib_to_netcdf",
             "make_live_ocean_files",
-            "make_ssh_files",
             "make_runoff_file",
             "make_v202111_runoff_file",
         }


### PR DESCRIPTION
We need to ensure that `make_v202111_runoff_file` runs 
after all the river discharge observations have been collected.
This PR implements a practical solution of launching `make_runoff_file` and `make_v2021_runoff_file` 
after `make_ssh_files`.
We're forced into this solution because the race condition handling can't deal with ensuring that multiple 
instances of the same worker (`collect_river_data`) have completed.
