### PR TITLE
Add single variable-hour file cropping to crop_gribs worker

### DIFF
--- a/nowcast/workers/crop_gribs.py
+++ b/nowcast/workers/crop_gribs.py
@@ -115,6 +115,16 @@ def crop_gribs(parsed_args, config, *args):
         msc_var_name,
     )
 
+    if msc_var_name and var_hour:
+        # Crop a single variable-hour file
+        eccc_grib_file = eccc_grib_files.pop()
+        _write_ssc_grib_file(eccc_grib_file, config)
+        logger.info(
+            f"finished cropping ECCC grib file to SalishSeaCast subdomain: {eccc_grib_file}"
+        )
+        checklist[fcst_hr] = "cropped to SalishSeaCast subdomain"
+        return checklist
+
     handler = _GribFileEventHandler(eccc_grib_files, config)
     observer = watchdog.observers.Observer()
     grib_dir = Path(config["weather"]["download"]["2.5 km"]["GRIB dir"])
@@ -131,7 +141,7 @@ def crop_gribs(parsed_args, config, *args):
     observer.stop()
     observer.join()
     logger.info(
-        f"finished cropping ECCC grib files to SalishSeaCast subdomain in {grib_fcst_dir}"
+        f"finished cropping ECCC grib files to SalishSeaCast subdomain in {grib_fcst_dir}/"
     )
     checklist[fcst_hr] = "cropped to SalishSeaCast subdomain"
     return checklist

--- a/tests/workers/test_crop_gribs.py
+++ b/tests/workers/test_crop_gribs.py
@@ -102,6 +102,17 @@ class TestMain:
         assert worker.cli.parser._actions[4].default == arrow.now().floor("day")
         assert worker.cli.parser._actions[4].help
 
+    def test_add_forecast_hour_option(self, mock_worker):
+        worker = crop_gribs.main()
+        assert worker.cli.parser._actions[5].dest == "var_hour"
+        assert worker.cli.parser._actions[5].type == int
+        assert worker.cli.parser._actions[5].help
+
+    def test_add_variable_option(self, mock_worker):
+        worker = crop_gribs.main()
+        assert worker.cli.parser._actions[6].dest == "msc_var_name"
+        assert worker.cli.parser._actions[6].help
+
 
 class TestConfig:
     """Unit tests for production YAML config file elements related to worker."""
@@ -257,7 +268,10 @@ class TestCropGribs:
         self, forecast, mock_calc_grib_file_paths, mock_observer, config, caplog
     ):
         parsed_args = SimpleNamespace(
-            forecast=forecast, fcst_date=arrow.get("2023-07-21")
+            forecast=forecast,
+            fcst_date=arrow.get("2023-08-11"),
+            var_hour=None,
+            msc_var_name=None,
         )
         caplog.set_level(logging.DEBUG)
 
@@ -276,7 +290,10 @@ class TestCropGribs:
         monkeypatch,
     ):
         parsed_args = SimpleNamespace(
-            forecast=forecast, fcst_date=arrow.get("2023-07-21")
+            forecast=forecast,
+            fcst_date=arrow.get("2023-08-11"),
+            var_hour=None,
+            msc_var_name=None,
         )
         caplog.set_level(logging.DEBUG)
 
@@ -284,7 +301,7 @@ class TestCropGribs:
 
         assert caplog.records[0].levelname == "INFO"
         expected = (
-            f"cropping 2023-07-21 ECCC HRDPS 2.5km continental {forecast}Z GRIB files to "
+            f"cropping 2023-08-11 ECCC HRDPS 2.5km continental {forecast}Z GRIB files to "
             f"SalishSeaCast subdomain"
         )
         assert caplog.messages[0] == expected
@@ -320,6 +337,31 @@ class TestCalcGribFilePaths:
             Path(
                 "forcing/atmospheric/continental2.5/GRIB/20230403/12/002/"
                 "20230403T12Z_MSC_HRDPS_VGRD_AGL-10m_RLatLon0.0225_PT002H.grib2"
+            ),
+        }
+        assert grib_files == expected
+
+    def test_ECCC_grib_file_path_for_one_file(self, config):
+        file_tmpl = config["weather"]["download"]["2.5 km"]["ECCC file template"]
+        fcst_date = arrow.get("2023-08-11")
+        fcst_hr = "12"
+        fcst_dur = 28
+        msc_var_names = ["UGRD_AGL-10m", "VGRD_AGL-10m"]
+
+        grib_files = crop_gribs._calc_grib_file_paths(
+            file_tmpl,
+            fcst_date,
+            fcst_hr,
+            fcst_dur,
+            msc_var_names,
+            config,
+            "VGRD_AGL-10m",
+        )
+
+        expected = {
+            Path(
+                "forcing/atmospheric/continental2.5/GRIB/20230811/12/028/"
+                "20230811T12Z_MSC_HRDPS_VGRD_AGL-10m_RLatLon0.0225_PT028H.grib2"
             ),
         }
         assert grib_files == expected


### PR DESCRIPTION
Allow the crop_gribs worker to crop a specific forecast variable for a
specific forecast hour. This is primarily intended for recovery from
crop_gribs stalls when only 1 or a few files need to be cropped to finish
processing. The feature is added through the use of optional --var-hour and
--var arguments. Test cases for this new functionality are included.