### PR TITLE
Update URL for NOAA Neah Bay sea surface height data

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -195,10 +195,10 @@ ssh:
   download:
     # URL from which to download NOAA Neah Bay sea surface height obs/forecast files
     # **Must be quoted to project {} characters**
-    url template: 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/etss/prod/etss.{yyyymmdd}/etss.t{forecast}z.csv_tar'
+    url template: 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/petss/prod/etss.{yyyymmdd}/etss.t{forecast}z.csv.tar.gz'
     # Template for the downloaded CSV tarball file name
     # **Must be quoted to project {} characters**
-    tar file template: 'etss.{yyyymmdd}.t{forecast}z.csv_tar'
+    tar file template: 'etss.{yyyymmdd}.t{forecast}z.csv_tar_gz'
     # Template for the directory and file name of the CSV file to extract from the tarball
     # **Must be quoted to project {} characters**
     tarball csv file template: 'etss.{yyyymmdd}/t{forecast}z_csv/9443090.csv'

--- a/tests/workers/test_collect_NeahBay_ssh.py
+++ b/tests/workers/test_collect_NeahBay_ssh.py
@@ -41,9 +41,9 @@ def config(base_config):
                 """\
                 ssh:
                   download:
-                    url template: 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/etss/prod/etss.{yyyymmdd}/etss.t{forecast}z.csv_tar'
+                    url template: 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/petss/prod/etss.{yyyymmdd}/etss.t{forecast}z.csv,tar.gz'
                     tar file template: 'etss.{yyyymmdd}.t{forecast}z.csv_tar'
-                    tarball csv file template: 'etss.{yyyymmdd}/t{forecast}z_csv/9443090.csv'
+                    tarball csv file template: 'etss.{yyyymmdd}/t{forecast}z_csv/9443090.csv_tar_gz'
 
                   ssh dir: /results/forcing/sshNeahBay/
                 """
@@ -115,10 +115,11 @@ class TestConfig:
         ssh_download = prod_config["ssh"]["download"]
         assert (
             ssh_download["url template"]
-            == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/etss/prod/etss.{yyyymmdd}/etss.t{forecast}z.csv_tar"
+            == "https://nomads.ncep.noaa.gov/pub/data/nccf/com/petss/prod/etss.{yyyymmdd}/etss.t{forecast}z.csv.tar.gz"
         )
         assert (
-            ssh_download["tar file template"] == "etss.{yyyymmdd}.t{forecast}z.csv_tar"
+            ssh_download["tar file template"]
+            == "etss.{yyyymmdd}.t{forecast}z.csv_tar_gz"
         )
         assert (
             ssh_download["tarball csv file template"]

--- a/tests/workers/test_make_ssh_file.py
+++ b/tests/workers/test_make_ssh_file.py
@@ -43,7 +43,7 @@ def config(base_config):
 
                 ssh:
                   download:
-                    tar file template: 'etss.{yyyymmdd}.t{forecast}z.csv_tar'
+                    tar file template: 'etss.{yyyymmdd}.t{forecast}z.csv_tar_gz'
 
                   coordinates: /SalishSeaCast/grid/coordinates_seagrid_SalishSea2.nc
                   tidal predictions: /SalishSeaCast/tidal-predictions/
@@ -148,7 +148,8 @@ class TestConfig:
     def test_ssh_download_section(self, prod_config):
         ssh_download = prod_config["ssh"]["download"]
         assert (
-            ssh_download["tar file template"] == "etss.{yyyymmdd}.t{forecast}z.csv_tar"
+            ssh_download["tar file template"]
+            == "etss.{yyyymmdd}.t{forecast}z.csv_tar_gz"
         )
 
     def test_results_archive_section(self, prod_config):


### PR DESCRIPTION
Updated NOAA model is served at a slightly different URL and file name. Files are now gz compressed tarballs. The URL of the data source and the tarball file names have been changed to reflect this in config/nowcast.yaml and the respective worker test files.