### PR TITLE
Add Hatch wheel build target to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,5 +119,8 @@ source = ["nowcast", "tests"]
 show_missing = true
 
 
+[tool.hatch.build.targets.wheel]
+packages = ["nowcast"]
+
 [tool.hatch.version]
 path = "nowcast/__about__.py"


### PR DESCRIPTION
Hatchling 1.19.0 changed the package identification heuristics such that an explicit declaration of the code directory tree to build the wheel for installation from is now required.