### PR TITLE
Change to V21-11 ERDDAP dataset ids

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -441,7 +441,6 @@ erddap:
       - ubcSSg3DvGridFields1hV21-11
       - ubcSSg3DwGridFields1hV21-11
       - ubcSSgVariableVolumeLayers1hV21-11
-      - ubcSSg3DAuxiliaryFields1hV19-05
     nemo-forecast:
       # tide gauge station water levels
       - ubcSSfBoundaryBaySSH10m

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -440,6 +440,7 @@ erddap:
       - ubcSSg3DuGridFields1hV21-11
       - ubcSSg3DvGridFields1hV21-11
       - ubcSSg3DwGridFields1hV21-11
+      - ubcSSgVariableVolumeLayers1hV21-11
       - ubcSSg3DAuxiliaryFields1hV19-05
     nemo-forecast:
       # tide gauge station water levels

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -433,7 +433,7 @@ erddap:
       - ubcONCTWDP1mV1
     nowcast-green:
       - ubcSSg3DBiologyFields1hV21-11
-      - ubcSSg3DTracerFields1hV19-05
+      - ubcSSg3DPhysicsFields1hV21-11
       - ubcSSg3DuGridFields1hV21-11
       - ubcSSg3DvGridFields1hV21-11
       - ubcSSg3DwGridFields1hV21-11

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -434,6 +434,7 @@ erddap:
     nowcast-green:
       - ubcSSg3DBiologyFields1hV21-11
       - ubcSSg3DChemistryFields1hV21-11
+      - ubcSSgSeaSurfaceCO2FluxField1hV21-11
       - ubcSSg3DPhysicsFields1hV21-11
       - ubcSSgSeaSurfaceHeightField1hV21-11
       - ubcSSg3DuGridFields1hV21-11

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -433,6 +433,7 @@ erddap:
       - ubcONCTWDP1mV1
     nowcast-green:
       - ubcSSg3DBiologyFields1hV21-11
+      - ubcSSg3DLightFields1hV21-11
       - ubcSSg3DChemistryFields1hV21-11
       - ubcSSgSeaSurfaceCO2FluxField1hV21-11
       - ubcSSg3DPhysicsFields1hV21-11

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -434,10 +434,10 @@ erddap:
     nowcast-green:
       - ubcSSg3DBiologyFields1hV21-11
       - ubcSSg3DPhysicsFields1hV21-11
+      - ubcSSgSeaSurfaceHeightField1hV21-11
       - ubcSSg3DuGridFields1hV21-11
       - ubcSSg3DvGridFields1hV21-11
       - ubcSSg3DwGridFields1hV21-11
-      - ubcSSgSurfaceTracerFields1hV19-05
       - ubcSSg3DAuxiliaryFields1hV19-05
     nemo-forecast:
       # tide gauge station water levels

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -433,6 +433,7 @@ erddap:
       - ubcONCTWDP1mV1
     nowcast-green:
       - ubcSSg3DBiologyFields1hV21-11
+      - ubcSSg3DChemistryFields1hV21-11
       - ubcSSg3DPhysicsFields1hV21-11
       - ubcSSgSeaSurfaceHeightField1hV21-11
       - ubcSSg3DuGridFields1hV21-11

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -432,7 +432,7 @@ erddap:
     TWDP-ferry:
       - ubcONCTWDP1mV1
     nowcast-green:
-      - ubcSSg3DBiologyFields1hV19-05
+      - ubcSSg3DBiologyFields1hV21-11
       - ubcSSg3DTracerFields1hV19-05
       - ubcSSg3DuGridFields1hV21-11
       - ubcSSg3DvGridFields1hV21-11

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -434,9 +434,9 @@ erddap:
     nowcast-green:
       - ubcSSg3DBiologyFields1hV19-05
       - ubcSSg3DTracerFields1hV19-05
-      - ubcSSg3DuGridFields1hV19-05
-      - ubcSSg3DvGridFields1hV19-05
-      - ubcSSg3DwGridFields1hV19-05
+      - ubcSSg3DuGridFields1hV21-11
+      - ubcSSg3DvGridFields1hV21-11
+      - ubcSSg3DwGridFields1hV21-11
       - ubcSSgSurfaceTracerFields1hV19-05
       - ubcSSg3DAuxiliaryFields1hV19-05
     nemo-forecast:

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -441,7 +441,7 @@ erddap:
       - ubcSSg3DuGridFields1hV21-11
       - ubcSSg3DvGridFields1hV21-11
       - ubcSSg3DwGridFields1hV21-11
-      - ubcSSgVariableVolumeLayers1hV21-11
+      - ubcSSg3DVariableVolumeLayers1hV21-11
     nemo-forecast:
       # tide gauge station water levels
       - ubcSSfBoundaryBaySSH10m

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -164,7 +164,6 @@ class TestConfig:
             "ubcSSg3DvGridFields1hV21-11",
             "ubcSSg3DwGridFields1hV21-11",
             "ubcSSgVariableVolumeLayers1hV21-11",
-            "ubcSSg3DAuxiliaryFields1hV19-05",
         ]
         assert erddap["datasetIDs"]["nemo-forecast"] == [
             "ubcSSfBoundaryBaySSH10m",

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -156,7 +156,7 @@ class TestConfig:
         assert erddap["datasetIDs"]["TWDP-ferry"] == ["ubcONCTWDP1mV1"]
         assert erddap["datasetIDs"]["nowcast-green"] == [
             "ubcSSg3DBiologyFields1hV21-11",
-            "ubcSSg3DTracerFields1hV19-05",
+            "ubcSSg3DPhysicsFields1hV21-11",
             "ubcSSg3DuGridFields1hV21-11",
             "ubcSSg3DvGridFields1hV21-11",
             "ubcSSg3DwGridFields1hV21-11",

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -156,6 +156,7 @@ class TestConfig:
         assert erddap["datasetIDs"]["TWDP-ferry"] == ["ubcONCTWDP1mV1"]
         assert erddap["datasetIDs"]["nowcast-green"] == [
             "ubcSSg3DBiologyFields1hV21-11",
+            "ubcSSg3DLightFields1hV21-11",
             "ubcSSg3DChemistryFields1hV21-11",
             "ubcSSgSeaSurfaceCO2FluxField1hV21-11",
             "ubcSSg3DPhysicsFields1hV21-11",

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -157,6 +157,7 @@ class TestConfig:
         assert erddap["datasetIDs"]["nowcast-green"] == [
             "ubcSSg3DBiologyFields1hV21-11",
             "ubcSSg3DChemistryFields1hV21-11",
+            "ubcSSgSeaSurfaceCO2FluxField1hV21-11",
             "ubcSSg3DPhysicsFields1hV21-11",
             "ubcSSgSeaSurfaceHeightField1hV21-11",
             "ubcSSg3DuGridFields1hV21-11",

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -164,7 +164,7 @@ class TestConfig:
             "ubcSSg3DuGridFields1hV21-11",
             "ubcSSg3DvGridFields1hV21-11",
             "ubcSSg3DwGridFields1hV21-11",
-            "ubcSSgVariableVolumeLayers1hV21-11",
+            "ubcSSg3DVariableVolumeLayers1hV21-11",
         ]
         assert erddap["datasetIDs"]["nemo-forecast"] == [
             "ubcSSfBoundaryBaySSH10m",

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -156,6 +156,7 @@ class TestConfig:
         assert erddap["datasetIDs"]["TWDP-ferry"] == ["ubcONCTWDP1mV1"]
         assert erddap["datasetIDs"]["nowcast-green"] == [
             "ubcSSg3DBiologyFields1hV21-11",
+            "ubcSSg3DChemistryFields1hV21-11",
             "ubcSSg3DPhysicsFields1hV21-11",
             "ubcSSgSeaSurfaceHeightField1hV21-11",
             "ubcSSg3DuGridFields1hV21-11",

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -157,9 +157,9 @@ class TestConfig:
         assert erddap["datasetIDs"]["nowcast-green"] == [
             "ubcSSg3DBiologyFields1hV19-05",
             "ubcSSg3DTracerFields1hV19-05",
-            "ubcSSg3DuGridFields1hV19-05",
-            "ubcSSg3DvGridFields1hV19-05",
-            "ubcSSg3DwGridFields1hV19-05",
+            "ubcSSg3DuGridFields1hV21-11",
+            "ubcSSg3DvGridFields1hV21-11",
+            "ubcSSg3DwGridFields1hV21-11",
             "ubcSSgSurfaceTracerFields1hV19-05",
             "ubcSSg3DAuxiliaryFields1hV19-05",
         ]

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -157,10 +157,10 @@ class TestConfig:
         assert erddap["datasetIDs"]["nowcast-green"] == [
             "ubcSSg3DBiologyFields1hV21-11",
             "ubcSSg3DPhysicsFields1hV21-11",
+            "ubcSSgSeaSurfaceHeightField1hV21-11",
             "ubcSSg3DuGridFields1hV21-11",
             "ubcSSg3DvGridFields1hV21-11",
             "ubcSSg3DwGridFields1hV21-11",
-            "ubcSSgSurfaceTracerFields1hV19-05",
             "ubcSSg3DAuxiliaryFields1hV19-05",
         ]
         assert erddap["datasetIDs"]["nemo-forecast"] == [

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -163,6 +163,7 @@ class TestConfig:
             "ubcSSg3DuGridFields1hV21-11",
             "ubcSSg3DvGridFields1hV21-11",
             "ubcSSg3DwGridFields1hV21-11",
+            "ubcSSgVariableVolumeLayers1hV21-11",
             "ubcSSg3DAuxiliaryFields1hV19-05",
         ]
         assert erddap["datasetIDs"]["nemo-forecast"] == [

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -155,7 +155,7 @@ class TestConfig:
         # assert erddap["datasetIDs"]["USDDL-CTD"] == ["ubcONCUSDDLCTD15mV1"]
         assert erddap["datasetIDs"]["TWDP-ferry"] == ["ubcONCTWDP1mV1"]
         assert erddap["datasetIDs"]["nowcast-green"] == [
-            "ubcSSg3DBiologyFields1hV19-05",
+            "ubcSSg3DBiologyFields1hV21-11",
             "ubcSSg3DTracerFields1hV19-05",
             "ubcSSg3DuGridFields1hV21-11",
             "ubcSSg3DvGridFields1hV21-11",


### PR DESCRIPTION
Use V21-11 dataset ids to create flags to update datasets on ERDDAP after nowcast-green run.

- [x] ubcSSg3DuGridFields1hV21-11
- [x] ubcSSg3DvGridFields1hV21-11
- [x] ubcSSg3DwGridFields1hV21-11
- [x] ubcSSg3DBiologyFields1hV21-11
- [x] ubcSSg3DPhysicsFields1hV21-11 in place of ubcSSg3DTracerFields1hV19-05
- [x] ubcSSg3DChemistryFields1hV21-11
- [x] ubcSSgSeaSurfaceHeightField1hV21-11 in place of ubcSSgSurfaceTracerFields1hV19-05
- [x] ubcSSgSeaSurfaceCO2FluxField1hV21-11
- [x] ubcSSg3DVariableVolumeLayers1hV21-11
- [x] ubcSSg3DLightFields1hV21-11