### PR TITLE
Automate creation of day and month averaged biology, chemistry & physics datasets

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -1579,8 +1579,18 @@ message registry:
 
     make_averaged_dataset:
       checklist key: averaged dataset
-      success: dataset averaged
-      failure: dataset averaging failed
+      success day biology: biology dataset day-averaged
+      failure day biology: biology dataset day-averaging failed
+      success day chemistry: chemistry dataset day-averaged
+      failure day chemistry: chemistry dataset day-averaging failed
+      success day physics: physics dataset day-averaged
+      failure day physics: physics dataset day-averaging failed
+      success month biology: biology dataset month-averaged
+      failure month biology: biology dataset month-averaging failed
+      success month chemistry: chemistry dataset month-averaged
+      failure month chemistry: chemistry dataset month-averaging failed
+      success month physics: physics dataset month-averaged
+      failure month physics: physics dataset month-averaging failed
       crash: make_averaged_dataset worker crashed
 
     archive_tarball:

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -1115,13 +1115,6 @@ logging:
         handlers:
           - hindcast_info
           - hindcast_debug
-      make_averaged_dataset:
-        qualname: make_averaged_dataset
-        level: DEBUG
-        propagate: False
-        handlers:
-          - hindcast_info
-          - hindcast_debug
       reshapr:
         qualname: reshapr
         level: DEBUG

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1509,7 +1509,7 @@ def after_download_results(msg, config, checklist):
                     next_workers[msg.type].append(
                         NextWorker(
                             "nowcast.workers.make_averaged_dataset",
-                            args=["skookum", "day", var_group, "--run-date", run_date],
+                            args=["day", var_group, "--run-date", run_date],
                         )
                     )
                 if arrow.get(run_date).shift(days=+1).day == 1:
@@ -1571,13 +1571,7 @@ def after_make_averaged_dataset(msg, config, checklist):
             next_workers[msg.type].append(
                 NextWorker(
                     "nowcast.workers.make_averaged_dataset",
-                    args=[
-                        "skookum",
-                        "month",
-                        reshapr_var_group,
-                        "--run-date",
-                        first_of_month,
-                    ],
+                    args=["month", reshapr_var_group, "--run-date", first_of_month],
                     host="localhost",
                 )
             )

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1503,8 +1503,15 @@ def after_download_results(msg, config, checklist):
                 )
             if run_type == "nowcast-green":
                 next_workers[msg.type].append(
-                    NextWorker("nowcast.workers.ping_erddap", args=["nowcast-green"])
+                    NextWorker("nowcast.workers.ping_erddap", args=["nowcast-green"]),
                 )
+                for var_group in {"biology", "chemistry", "physics"}:
+                    next_workers[msg.type].append(
+                        NextWorker(
+                            "nowcast.workers.make_averaged_dataset",
+                            args=["skookum", "day", var_group, "--run-date", run_date],
+                        )
+                    )
                 if arrow.get(run_date).shift(days=+1).day == 1:
                     yyyymmm = arrow.get(run_date).format("YYYY-MMM").lower()
                     next_workers[msg.type].append(

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1548,7 +1548,40 @@ def after_make_averaged_dataset(msg, config, checklist):
     :returns: Worker(s) to launch next
     :rtype: list
     """
-    return []
+    next_workers = {
+        "crash": [],
+        "failure day biology": [],
+        "failure day chemistry": [],
+        "failure day physics": [],
+        "failure month biology": [],
+        "failure month chemistry": [],
+        "failure month physics": [],
+        "success day biology": [],
+        "success day chemistry": [],
+        "success day physics": [],
+        "success month biology": [],
+        "success month chemistry": [],
+        "success month physics": [],
+    }
+    if msg.type.startswith("success day"):
+        *_, reshapr_var_group = msg.type.split()
+        run_date = arrow.get(msg.payload[f"day {reshapr_var_group}"]["run date"])
+        if run_date.shift(days=+1).day == 1:
+            first_of_month = run_date.format("YYYY-MM-01")
+            next_workers[msg.type].append(
+                NextWorker(
+                    "nowcast.workers.make_averaged_dataset",
+                    args=[
+                        "skookum",
+                        "month",
+                        reshapr_var_group,
+                        "--run-date",
+                        first_of_month,
+                    ],
+                    host="localhost",
+                )
+            )
+    return next_workers[msg.type]
 
 
 def after_archive_tarball(msg, config, checklist):

--- a/nowcast/workers/make_averaged_dataset.py
+++ b/nowcast/workers/make_averaged_dataset.py
@@ -125,7 +125,7 @@ def success(parsed_args):
                 f"{avg_time_interval}-averaged dataset for {run_date.format('MMM-YYYY')} "
                 f"{reshapr_var_group} created on {host_name}"
             )
-    msg_type = "success"
+    msg_type = f"success {avg_time_interval} {reshapr_var_group}"
     return msg_type
 
 
@@ -145,7 +145,7 @@ def failure(parsed_args):
                 f"{avg_time_interval}-averaged dataset for {run_date.format('MMM-YYYY')} "
                 f"{reshapr_var_group} creation on {host_name} failed"
             )
-    msg_type = "failure"
+    msg_type = f"failure {avg_time_interval} {reshapr_var_group}"
     return msg_type
 
 

--- a/nowcast/workers/make_averaged_dataset.py
+++ b/nowcast/workers/make_averaged_dataset.py
@@ -48,9 +48,6 @@ def main():
     worker = NowcastWorker(NAME, description=__doc__)
     worker.init_cli()
     worker.cli.add_argument(
-        "host_name", help="Name of the host to run the downsampling extraction on"
-    )
-    worker.cli.add_argument(
         "avg_time_interval",
         choices={"day", "month"},
         help="Time interval over which to average the dataset",

--- a/nowcast/workers/make_averaged_dataset.py
+++ b/nowcast/workers/make_averaged_dataset.py
@@ -195,9 +195,10 @@ def make_averaged_dataset(parsed_args, config, *args):
         dest_nc_filename = file_pattern.format(yyyymmdd=run_date.format("YYYYMMDD"))
         nc_path = nc_path.rename(nc_path.with_name(dest_nc_filename))
     return {
-        f"{run_date.format('YYYY-MM-DD')} {avg_time_interval} {reshapr_var_group}": os.fspath(
-            nc_path
-        )
+        f"{avg_time_interval} {reshapr_var_group}": {
+            "run date": run_date.format("YYYY-MM-DD"),
+            "file path": os.fspath(nc_path),
+        }
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,7 +120,6 @@ class TestLoggingPublisher:
             "run_NEMO_hindcast",
             "watch_NEMO_hindcast",
             "split_results",
-            "make_averaged_dataset",
             "reshapr",
             "checklist",
             "cfgrib",

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2200,7 +2200,21 @@ class TestAfterDownloadResults:
 class TestAfterMakeAveragedDataset:
     """Unit tests for the after_make_averaged_dataset function."""
 
-    @pytest.mark.parametrize("msg_type", ["crash", "failure", "success"])
+    @pytest.mark.parametrize(
+        "msg_type",
+        [
+            "crash",
+            "failure day biology",
+            "failure day chemistry",
+            "failure day physics",
+            "success month biology",
+            "success month chemistry",
+            "success month physics",
+            "failure month biology",
+            "failure month chemistry",
+            "failure month physics",
+        ],
+    )
     def test_no_next_worker_msg_types(self, msg_type, config, checklist):
         workers = next_workers.after_make_averaged_dataset(
             Message("make_averaged_dataset", msg_type), config, checklist

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2221,6 +2221,36 @@ class TestAfterMakeAveragedDataset:
         )
         assert workers == []
 
+    @pytest.mark.parametrize(
+        "msg_type",
+        [
+            "success day biology",
+            "success day chemistry",
+            "success day physics",
+        ],
+    )
+    def test_month_end_day_success_launch_month_average(
+        self, msg_type, config, checklist
+    ):
+        *_, reshapr_var_group = msg_type.split()
+        msg = Message(
+            "make_averaged_dataset",
+            msg_type,
+            payload={
+                f"day {reshapr_var_group}": {
+                    "run date": "2024-02-29",
+                    "file path": "SalishSea_1d_20240301_20240301_biol_T.nc",
+                }
+            },
+        )
+        workers = next_workers.after_make_averaged_dataset(msg, config, checklist)
+        expected = NextWorker(
+            "nowcast.workers.make_averaged_dataset",
+            args=["skookum", "month", reshapr_var_group, "--run-date", "2024-02-01"],
+            host="localhost",
+        )
+        assert expected in workers
+
 
 class TestAfterArchiveTarball:
     """Unit tests for the after_archive_tarball function."""

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2104,7 +2104,7 @@ class TestAfterDownloadResults:
         )
         expected = NextWorker(
             "nowcast.workers.make_averaged_dataset",
-            args=["skookum", "day", var_group, "--run-date", "2024-02-07"],
+            args=["day", var_group, "--run-date", "2024-02-07"],
             host="localhost",
         )
         assert expected in workers
@@ -2246,7 +2246,7 @@ class TestAfterMakeAveragedDataset:
         workers = next_workers.after_make_averaged_dataset(msg, config, checklist)
         expected = NextWorker(
             "nowcast.workers.make_averaged_dataset",
-            args=["skookum", "month", reshapr_var_group, "--run-date", "2024-02-01"],
+            args=["month", reshapr_var_group, "--run-date", "2024-02-01"],
             host="localhost",
         )
         assert expected in workers

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2089,6 +2089,26 @@ class TestAfterDownloadResults:
         )
         assert expected in workers
 
+    @pytest.mark.parametrize("var_group", ("biology", "chemistry", "physics"))
+    def test_success_nowcast_green_launch_make_averaged_dataset_day(
+        self, var_group, config, checklist
+    ):
+        workers = next_workers.after_download_results(
+            Message(
+                "download_results",
+                "success nowcast-green",
+                payload={"nowcast-green": {"run date": "2024-02-07"}},
+            ),
+            config,
+            checklist,
+        )
+        expected = NextWorker(
+            "nowcast.workers.make_averaged_dataset",
+            args=["skookum", "day", var_group, "--run-date", "2024-02-07"],
+            host="localhost",
+        )
+        assert expected in workers
+
     def test_success_nowcast_green_not_monthend_no_launch_archive_tarball(
         self, config, checklist
     ):

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -138,8 +138,18 @@ class TestConfig:
 
         assert list(msg_registry.keys()) == [
             "checklist key",
-            "success",
-            "failure",
+            "success day biology",
+            "failure day biology",
+            "success day chemistry",
+            "failure day chemistry",
+            "success day physics",
+            "failure day physics",
+            "success month biology",
+            "failure month biology",
+            "success month chemistry",
+            "failure month chemistry",
+            "success month physics",
+            "failure month physics",
             "crash",
         ]
 
@@ -238,7 +248,7 @@ class TestSuccess:
         host_name = parsed_args.host_name
         expected = f"{avg_time_interval}-averaged dataset for 10-Nov-2022 {reshapr_var_group} created on {host_name}"
         assert caplog.messages[0] == expected
-        assert msg_type == "success"
+        assert msg_type == f"success {avg_time_interval} {reshapr_var_group}"
 
     @pytest.mark.parametrize(
         "avg_time_interval, reshapr_var_group",
@@ -265,7 +275,7 @@ class TestSuccess:
         host_name = parsed_args.host_name
         expected = f"{avg_time_interval}-averaged dataset for Nov-2022 {reshapr_var_group} created on {host_name}"
         assert caplog.messages[0] == expected
-        assert msg_type == "success"
+        assert msg_type == f"success {avg_time_interval} {reshapr_var_group}"
 
 
 class TestFailure:
@@ -296,7 +306,7 @@ class TestFailure:
         host_name = parsed_args.host_name
         expected = f"{avg_time_interval}-averaged dataset for 10-Nov-2022 {reshapr_var_group} creation on {host_name} failed"
         assert caplog.messages[0] == expected
-        assert msg_type == "failure"
+        assert msg_type == f"failure {avg_time_interval} {reshapr_var_group}"
 
     @pytest.mark.parametrize(
         "avg_time_interval, reshapr_var_group",
@@ -323,7 +333,7 @@ class TestFailure:
         host_name = parsed_args.host_name
         expected = f"{avg_time_interval}-averaged dataset for Nov-2022 {reshapr_var_group} creation on {host_name} failed"
         assert caplog.messages[0] == expected
-        assert msg_type == "failure"
+        assert msg_type == f"failure {avg_time_interval} {reshapr_var_group}"
 
 
 class TestMakeAveragedDataset:

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -86,37 +86,31 @@ class TestMain:
             "SalishSeaCast worker that creates a down-sampled time-series dataset netCDF4 file"
         )
 
-    def test_add_host_name_arg(self, mock_worker):
-        worker = make_averaged_dataset.main()
-
-        assert worker.cli.parser._actions[3].dest == "host_name"
-        assert worker.cli.parser._actions[3].help
-
     def test_add_avg_time_interval_arg(self, mock_worker):
         worker = make_averaged_dataset.main()
 
-        assert worker.cli.parser._actions[4].dest == "avg_time_interval"
-        assert worker.cli.parser._actions[4].choices == {"day", "month"}
-        assert worker.cli.parser._actions[4].help
+        assert worker.cli.parser._actions[3].dest == "avg_time_interval"
+        assert worker.cli.parser._actions[3].choices == {"day", "month"}
+        assert worker.cli.parser._actions[3].help
 
     def test_add_reshapr_var_group_arg(self, mock_worker):
         worker = make_averaged_dataset.main()
 
-        assert worker.cli.parser._actions[5].dest == "reshapr_var_group"
-        assert worker.cli.parser._actions[5].choices == {
+        assert worker.cli.parser._actions[4].dest == "reshapr_var_group"
+        assert worker.cli.parser._actions[4].choices == {
             "biology",
             "chemistry",
             "physics",
         }
-        assert worker.cli.parser._actions[5].help
+        assert worker.cli.parser._actions[4].help
 
     def test_add_run_date_option(self, mock_worker):
         worker = make_averaged_dataset.main()
-        assert worker.cli.parser._actions[6].dest == "run_date"
+        assert worker.cli.parser._actions[5].dest == "run_date"
         expected = nemo_nowcast.cli.CommandLineInterface.arrow_date
-        assert worker.cli.parser._actions[6].type == expected
-        assert worker.cli.parser._actions[6].default == arrow.now().floor("day")
-        assert worker.cli.parser._actions[6].help
+        assert worker.cli.parser._actions[5].type == expected
+        assert worker.cli.parser._actions[5].default == arrow.now().floor("day")
+        assert worker.cli.parser._actions[5].help
 
 
 class TestConfig:

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -388,9 +388,10 @@ class TestMakeAveragedDataset:
         )
         assert caplog.messages[0] == expected
         expected = {
-            f"2022-11-16 {avg_time_interval} {reshapr_var_group}": os.fspath(
-                tmp_path / "16nov22" / nc_filename
-            )
+            f"{avg_time_interval} {reshapr_var_group}": {
+                "run date": "2022-11-16",
+                "file path": os.fspath(tmp_path / "16nov22" / nc_filename),
+            }
         }
         assert checklist == expected
 
@@ -440,13 +441,14 @@ class TestMakeAveragedDataset:
         )
         assert caplog.messages[0] == expected
         expected = {
-            f"2022-11-01 {avg_time_interval} {reshapr_var_group}": os.fspath(
-                tmp_path / "test_results.nc"
-            )
+            f"{avg_time_interval} {reshapr_var_group}": {
+                "run date": "2022-11-01",
+                "file path": os.fspath(tmp_path / "test_results.nc"),
+            }
         }
         assert checklist == expected
 
-    def test_bad_month_avg_run_date(self, caplog):
+    def test_bad_month_avg_run_date(self, caplog, config):
         parsed_args = SimpleNamespace(
             avg_time_interval="month",
             run_date=arrow.get("2022-11-10"),


### PR DESCRIPTION
Launch `make_averaged_dataset` to calculate day-averaged datasets for nowcast-green runs after run results files are downloaded.

Launch `make_averaged_dataset` to calculate month-averaged datasets for nowcast-green runs after completion of day-averaged datasets calculation on the last day of the month.

Expanded the list of message types for `make_averaged_dataset`.
Refactored the checklist data structure it sends to the manager in its message payload.
The latter make it easier for `after_*` functions in the `next_workers` module to access the run date and averaged dataset file path.