### PR TITLE
Fix broken web site time series plots.

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -541,8 +541,8 @@ figures:
     tide stn ssh time series:
       # **Must be quoted to project {} characters**
       "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf{place}SSH10m"
-    3d tracer fields:
-      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV21-11
+    3d physics fields:
+      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DPhysicsFields1hV21-11
     3d biology fields:
       https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV21-11
     2nd narrows hadcp time series:

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -542,9 +542,9 @@ figures:
       # **Must be quoted to project {} characters**
       "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf{place}SSH10m"
     3d tracer fields:
-      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV19-05
+      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV21-11
     3d biology fields:
-      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV19-05
+      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV21-11
     2nd narrows hadcp time series:
       https://salishsea.eos.ubc.ca/erddap/tabledap/ubcVFPA2ndNarrowsCurrent2sV1
     wwatch3 fields:

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -540,7 +540,7 @@ figures:
       https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaSurfaceAtmosphereFieldsV1
     tide stn ssh time series:
       # **Must be quoted to project {} characters**
-      'https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf{place}SSH10m'
+      "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf{place}SSH10m"
     3d tracer fields:
       https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV19-05
     3d biology fields:

--- a/nowcast/figures/website_theme.py
+++ b/nowcast/figures/website_theme.py
@@ -65,6 +65,8 @@ COLOURS = {
         "flagellates": "darkgreen",
         "mesozooplankton": "brown",
         "microzooplankton": "darkgreen",
+        "z1_zooplankton": "brown",
+        "z2_zooplankton": "darkgreen",
         "nitrate": "darkgreen",
         "salinity": "blue",
         "2nd Narrows model current direction": {"x2": "blue", "r12": "purple"},

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -616,9 +616,9 @@ def _prep_nowcast_green_research_fig_functions(
                 "function": time_series_plots.make_figure,
                 "args": (bio_dataset, "nitrate", "diatoms", place),
             },
-            "mesodinium_flagellates_timeseries": {
+            "diatoms_flagellates_timeseries": {
                 "function": time_series_plots.make_figure,
-                "args": (bio_dataset, "microzooplankton", "flagellates", place),
+                "args": (bio_dataset, "diatoms", "flagellates", place),
             },
             "z1_z2_zooplankton_timeseries": {
                 "function": time_series_plots.make_figure,

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -682,7 +682,6 @@ def _prep_comparison_fig_functions(
         f"preparing render list for {run_date.format('YYYY-MM-DD')} NEMO nowcast-blue comparison figures"
     )
     hrdps_dataset_url = config["figures"]["dataset URLs"]["HRDPS fields"]
-    ferry_data_dir = config["observations"]["ferry data"]
     dev_results_dir = os.path.join(dev_results_home, dmy)
     grid_T_hr = _results_dataset("1h", "grid_T", results_dir)
     dev_grid_T_hr = _results_dataset("1h", "grid_T", dev_results_dir)

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -139,6 +139,7 @@ def main():
         """,
     )
     worker.run(make_plots, success, failure)
+    return worker
 
 
 def success(parsed_args):

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -620,9 +620,9 @@ def _prep_nowcast_green_research_fig_functions(
                 "function": time_series_plots.make_figure,
                 "args": (bio_dataset, "microzooplankton", "flagellates", place),
             },
-            "mesozoo_microzoo_timeseries": {
+            "z1_z2_zooplankton_timeseries": {
                 "function": time_series_plots.make_figure,
-                "args": (bio_dataset, "mesozooplankton", "microzooplankton", place),
+                "args": (bio_dataset, "z1_zooplankton", "z2_zooplankton", place),
             },
         }
     )

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -156,8 +156,7 @@ def success(parsed_args):
 def failure(parsed_args):
     logger.critical(
         f"{parsed_args.model} {parsed_args.plot_type} plots failed for "
-        f'{parsed_args.run_date.format("YYYY-MM-DD")} {parsed_args.run_type} '
-        f"failed"
+        f'{parsed_args.run_date.format("YYYY-MM-DD")} {parsed_args.run_type}'
     )
     msg_type = (
         f"failure {parsed_args.model} {parsed_args.run_type} "

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -64,9 +64,7 @@ logger = logging.getLogger(NAME)
 
 
 def main():
-    """Set up and run the worker.
-
-    For command-line usage see:
+    """For command-line usage see:
 
     :command:`python -m nowcast.workers.make_plots --help`
     """

--- a/nowcast/workers/make_plots.py
+++ b/nowcast/workers/make_plots.py
@@ -601,7 +601,7 @@ def _prep_nowcast_green_research_fig_functions(
         )
     place = "S3"
     phys_dataset = xarray.open_dataset(
-        config["figures"]["dataset URLs"]["3d tracer fields"]
+        config["figures"]["dataset URLs"]["3d physics fields"]
     )
     bio_dataset = xarray.open_dataset(
         config["figures"]["dataset URLs"]["3d biology fields"]

--- a/tests/workers/test_make_plots.py
+++ b/tests/workers/test_make_plots.py
@@ -144,6 +144,176 @@ class TestConfig:
         msg_registry = prod_config["message registry"]["workers"]["make_plots"]
         assert msg in msg_registry
 
+    def test_timezone(self, prod_config):
+        timezone = prod_config["figures"]["timezone"]
+
+        assert timezone == "Canada/Pacific"
+
+    def test_dev_results_archive(self, prod_config):
+        dev_results_archive = prod_config["results archive"]["nowcast-dev"]
+
+        assert dev_results_archive == "/results/SalishSea/nowcast-dev.201905/"
+
+    def test_weather_path(self, prod_config):
+        weather_path = prod_config["weather"]["ops dir"]
+
+        assert (
+            weather_path == "/results/forcing/atmospheric/continental2.5/nemo_forcing/"
+        )
+
+    @pytest.mark.parametrize(
+        "run_type, results_archive",
+        (
+            ("nowcast", "/results/SalishSea/nowcast-blue.202111/"),
+            ("nowcast-green", "/results2/SalishSea/nowcast-green.202111/"),
+            ("nowcast-agrif", "/results/SalishSea/nowcast-agrif.201702/"),
+            ("forecast", "/results/SalishSea/forecast.202111/"),
+            ("forecast2", "/results/SalishSea/forecast2.202111/"),
+        ),
+    )
+    def test_results_archives(self, run_type, results_archive, prod_config):
+        run_type_results_archive = prod_config["results archive"][run_type]
+
+        assert run_type_results_archive == results_archive
+
+    def test_grid_dir(self, prod_config):
+        grid_dir = prod_config["figures"]["grid dir"]
+
+        assert grid_dir == "/SalishSeaCast/grid/"
+
+    @pytest.mark.parametrize(
+        "run_type, bathymetry",
+        (
+            ("nowcast", "bathymetry_202108.nc"),
+            ("nowcast-green", "bathymetry_202108.nc"),
+            ("nowcast-agrif", "bathymetry_201702.nc"),
+            ("forecast", "bathymetry_202108.nc"),
+            ("forecast2", "bathymetry_202108.nc"),
+        ),
+    )
+    def test_bathymetry(self, run_type, bathymetry, prod_config):
+        run_type_bathy = prod_config["run types"][run_type]["bathymetry"]
+
+        assert run_type_bathy == bathymetry
+
+    @pytest.mark.parametrize(
+        "run_type, mesh_mask",
+        (
+            ("nowcast", "mesh_mask202108.nc"),
+            ("nowcast-green", "mesh_mask202108.nc"),
+            ("nowcast-agrif", "mesh_mask201702.nc"),
+            ("forecast", "mesh_mask202108.nc"),
+            ("forecast2", "mesh_mask202108.nc"),
+        ),
+    )
+    def test_mesh_mask(self, run_type, mesh_mask, prod_config):
+        run_type_mesh_mask = prod_config["run types"][run_type]["mesh mask"]
+
+        assert run_type_mesh_mask == mesh_mask
+
+    def test_dev_mesh_mask(self, prod_config):
+        dev_mesh_mask = prod_config["run types"]["nowcast-dev"]["mesh mask"]
+
+        assert dev_mesh_mask == "mesh_mask201702.nc"
+
+    def test_coastline(self, prod_config):
+        coastline = prod_config["figures"]["coastline"]
+
+        assert coastline == "/ocean/rich/more/mmapbase/bcgeo/PNW.mat"
+
+    @pytest.mark.parametrize(
+        "dataset, dataset_url",
+        (
+            (
+                "tide stn ssh time series",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf{place}SSH10m",
+            ),
+            (
+                "2nd narrows hadcp time series",
+                "https://salishsea.eos.ubc.ca/erddap/tabledap/ubcVFPA2ndNarrowsCurrent2sV1",
+            ),
+            (
+                "wwatch3 fields",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf2DWaveFields30mV17-02",
+            ),
+            (
+                "3d tracer fields",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV19-05",
+            ),
+            (
+                "3d biology fields",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV19-05",
+            ),
+            (
+                "HRDPS fields",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaSurfaceAtmosphereFieldsV1",
+            ),
+        ),
+    )
+    def test_dataset_urls(self, dataset, dataset_url, prod_config):
+        url = prod_config["figures"]["dataset URLs"][dataset]
+
+        assert url == dataset_url
+
+    def test_agrif_bathymetryy(self, prod_config):
+        url = prod_config["figures"]["dataset URLs"]["bathymetry"]
+        bs_grid = prod_config["run types"]["nowcast-agrif"]["sub-grid bathymetry"]
+
+        assert (
+            url == "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV17-02"
+        )
+        assert (
+            bs_grid
+            == "/SalishSeaCast/grid/subgrids/BaynesSound/bathymetry_201702_BS.nc"
+        )
+
+    def test_tidal_predictions(self, prod_config):
+        tidal_predictions = prod_config["ssh"]["tidal predictions"]
+
+        assert tidal_predictions == "/SalishSeaCast/tidal-predictions/"
+
+    @pytest.mark.parametrize(
+        "run_type, duration",
+        (
+            ("nowcast", 1),
+            ("nowcast-green", 1),
+            ("nowcast-agrif", 1),
+            ("forecast", 1.5),
+            ("forecast2", 1.25),
+        ),
+    )
+    def test_durations(self, run_type, duration, prod_config):
+        run_type_duration = prod_config["run types"][run_type]["duration"]
+
+        assert run_type_duration == duration
+
+    def test_test_path(self, prod_config):
+        test_path = prod_config["figures"]["test path"]
+
+        assert test_path == "/results/nowcast-sys/figures/test/"
+
+    def test_storage_path(self, prod_config):
+        storage_path = prod_config["figures"]["storage path"]
+
+        assert storage_path == "/results/nowcast-sys/figures/"
+
+    def test_file_group(self, prod_config):
+        file_group = prod_config["file group"]
+
+        assert file_group == "sallen"
+
+    @pytest.mark.parametrize(
+        "key, expected_path",
+        (
+            ("storm surge alerts thumbnail", "Website_thumbnail"),
+            ("storm surge info portal path", "storm-surge/"),
+        ),
+    )
+    def test_storm_surge_paths(self, key, expected_path, prod_config):
+        path = prod_config["figures"][key]
+
+        assert path == expected_path
+
 
 @pytest.mark.parametrize(
     "model, run_type, plot_type",

--- a/tests/workers/test_make_plots.py
+++ b/tests/workers/test_make_plots.py
@@ -238,11 +238,11 @@ class TestConfig:
             ),
             (
                 "3d tracer fields",
-                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DTracerFields1hV19-05",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DPhysicsFields1hV21-11",
             ),
             (
                 "3d biology fields",
-                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV19-05",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DBiologyFields1hV21-11",
             ),
             (
                 "HRDPS fields",

--- a/tests/workers/test_make_plots.py
+++ b/tests/workers/test_make_plots.py
@@ -19,9 +19,10 @@
 """Unit tests for SalishSeaCast make_plots worker.
 """
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import arrow
+import nemo_nowcast
 import pytest
 
 from nowcast.workers import make_plots
@@ -33,36 +34,34 @@ def config(base_config):
     return base_config
 
 
-@patch("nowcast.workers.make_plots.NowcastWorker", spec=True)
+@pytest.fixture
+def mock_worker(mock_nowcast_worker, monkeypatch):
+    monkeypatch.setattr(make_plots, "NowcastWorker", mock_nowcast_worker)
+
+
 class TestMain:
     """Unit tests for main() function."""
 
-    def test_instantiate_worker(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker.call_args
-        assert args == ("make_plots",)
-        assert list(kwargs.keys()) == ["description"]
+    def test_instantiate_worker(self, mock_worker):
+        worker = make_plots.main()
 
-    def test_init_cli(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        m_worker().init_cli.assert_called_once_with()
+        assert worker.name == "make_plots"
+        assert worker.description.startswith(
+            "SalishSeaCast worker that produces visualization images for"
+        )
 
-    def test_add_model_arg(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker().cli.add_argument.call_args_list[0]
-        assert args == ("model",)
-        assert kwargs["choices"] == {"nemo", "fvcom", "wwatch3"}
-        assert "help" in kwargs
+    def test_add_model_arg(self, mock_worker):
+        worker = make_plots.main()
 
-    def test_add_run_type_arg(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker().cli.add_argument.call_args_list[1]
-        assert args == ("run_type",)
-        assert kwargs["choices"] == {
+        assert worker.cli.parser._actions[3].dest == "model"
+        assert worker.cli.parser._actions[3].choices == {"nemo", "fvcom", "wwatch3"}
+        assert worker.cli.parser._actions[3].help
+
+    def test_add_run_type_arg(self, mock_worker):
+        worker = make_plots.main()
+
+        assert worker.cli.parser._actions[4].dest == "run_type"
+        assert worker.cli.parser._actions[4].choices == {
             "nowcast",
             "nowcast-green",
             "nowcast-agrif",
@@ -72,36 +71,33 @@ class TestMain:
             "forecast2",
             "forecast-x2",
         }
-        assert "help" in kwargs
+        assert worker.cli.parser._actions[4].help
 
-    def test_add_plot_type_arg(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker().cli.add_argument.call_args_list[2]
-        assert args == ("plot_type",)
-        assert kwargs["choices"] == {"publish", "research", "comparison"}
-        assert "help" in kwargs
+    def test_add_plot_type_arg(self, mock_worker):
+        worker = make_plots.main()
 
-    def test_add_run_date_arg(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker().cli.add_date_option.call_args_list[0]
-        assert args == ("--run-date",)
-        assert kwargs["default"] == arrow.now().floor("day")
-        assert "help" in kwargs
+        assert worker.cli.parser._actions[5].dest == "plot_type"
+        assert worker.cli.parser._actions[5].choices == {
+            "publish",
+            "research",
+            "comparison",
+        }
+        assert worker.cli.parser._actions[5].help
 
-    def test_add_test_figure_arg(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker().cli.add_argument.call_args_list[3]
-        assert args == ("--test-figure",)
-        assert "help" in kwargs
+    def test_add_run_date_option(self, mock_worker):
+        worker = make_plots.main()
+        assert worker.cli.parser._actions[6].dest == "run_date"
+        expected = nemo_nowcast.cli.CommandLineInterface.arrow_date
+        assert worker.cli.parser._actions[6].type == expected
+        assert worker.cli.parser._actions[6].default == arrow.now().floor("day")
+        assert worker.cli.parser._actions[6].help
 
-    def test_run_worker(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_plots.main()
-        args, kwargs = m_worker().run.call_args
-        assert args == (make_plots.make_plots, make_plots.success, make_plots.failure)
+    def test_add_test_figure_arg(self, mock_worker):
+        worker = make_plots.main()
+
+        assert worker.cli.parser._actions[7].dest == "test_figure"
+        assert worker.cli.parser._actions[7].default is None
+        assert worker.cli.parser._actions[7].help
 
 
 class TestConfig:

--- a/tests/workers/test_make_plots.py
+++ b/tests/workers/test_make_plots.py
@@ -237,7 +237,7 @@ class TestConfig:
                 "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf2DWaveFields30mV17-02",
             ),
             (
-                "3d tracer fields",
+                "3d physics fields",
                 "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSg3DPhysicsFields1hV21-11",
             ),
             (


### PR DESCRIPTION
Web site time series plots broke when v202111 was released because the ERDDAP URLs that they use to access the model results were not updated.

Also improve `make_plots` worker unit tests:

- Replace unittest.mock.patch decorator with pytest caplog fixture re: issue #82 
- Add unit tests for production YAML config file elements related to worker re: issue #117