### PR TITLE
Update ERDDAP URL for HRDPS fields in config & tests

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -535,7 +535,7 @@ figures:
     bathymetry:
       https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSnBathymetryV17-02
     HRDPS fields:
-      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaSurfaceAtmosphereFieldsV1
+      https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaSurfaceAtmosphereFieldsV23-02
     tide stn ssh time series:
       # **Must be quoted to project {} characters**
       "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSf{place}SSH10m"

--- a/tests/workers/test_make_plots.py
+++ b/tests/workers/test_make_plots.py
@@ -246,7 +246,7 @@ class TestConfig:
             ),
             (
                 "HRDPS fields",
-                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaSurfaceAtmosphereFieldsV1",
+                "https://salishsea.eos.ubc.ca/erddap/griddap/ubcSSaSurfaceAtmosphereFieldsV23-02",
             ),
         ),
     )


### PR DESCRIPTION
The URL to access HRDPS fields from the SalishSeaCast ERDDAP service is updated. This modifies the `nowcast.yaml` configuration file and `test_make_plots.py` in the test suite. The new URL points to version 23-02 of the Surface Atmosphere Fields.