### PR TITLE
Change 'np.NaN' to 'np.nan' re: Numpy 2.0

### DIFF
--- a/nowcast/figures/research_ferries.py
+++ b/nowcast/figures/research_ferries.py
@@ -306,8 +306,8 @@ def _model_IDW(obs, bathy, grid_T_hr, sal_a, sal_b):
     # more of the surrounding grid point are land with NaN.
     interp_area = sal_a[x1 - 1 : x1 + 2, y1 - 1 : y1 + 2]
     if interp_area.size - np.count_nonzero(interp_area) >= 4:
-        sal_a_idw = np.NaN
-        sal_b_idw = np.NaN
+        sal_a_idw = np.nan
+        sal_b_idw = np.nan
     else:
         for i in np.arange(x1 - 1, x1 + 2):
             for j in np.arange(y1 - 1, y1 + 2):

--- a/nowcast/figures/shared.py
+++ b/nowcast/figures/shared.py
@@ -215,7 +215,7 @@ def interp_to_model_time(t_model, values, t_values):
     t_values_wrt_epoch = np.array([(t - epoch).total_seconds() for t in t_values])
     t_model_wrt_epoch = np.array([(t - epoch).total_seconds() for t in t_model])
     return np.interp(
-        t_model_wrt_epoch, t_values_wrt_epoch, values, left=np.NaN, right=np.NaN
+        t_model_wrt_epoch, t_values_wrt_epoch, values, left=np.nan, right=np.NaN
     )
 
 


### PR DESCRIPTION
 'numpy.nan' is the correct spelling in Numpy 2.0. All others are deprecated.