### PR TITLE
Fix various warnings revealed by pytest

### DIFF
--- a/nowcast/daily_river_flows.py
+++ b/nowcast/daily_river_flows.py
@@ -193,8 +193,8 @@ def _read_river_Theodosia(config):
     # Used for dates before Scotty part was gauged, or in the event of missing obs
     parts[2]["FlowFromDiversion"] = parts[2].Diversion * theodosia_from_diversion_only
     theodosia = theodosia.merge(parts[2], how="outer", on="date", sort=True)
-    theodosia["Secondary River Flow"].fillna(
-        theodosia["FlowFromDiversion"], inplace=True
+    theodosia["Secondary River Flow"] = theodosia["Secondary River Flow"].fillna(
+        theodosia["FlowFromDiversion"]
     )
 
     theodosia.drop(

--- a/nowcast/daily_river_flows.py
+++ b/nowcast/daily_river_flows.py
@@ -121,7 +121,7 @@ _read_river_csv = functools.partial(
     # .csv files
     pd.read_csv,
     header=None,
-    delim_whitespace=True,
+    sep="\\s+",
     index_col=False,
     names=["year", "month", "day", "flow"],
     engine="python",

--- a/nowcast/workers/make_v202111_runoff_file.py
+++ b/nowcast/workers/make_v202111_runoff_file.py
@@ -365,8 +365,8 @@ def _read_river_Theodosia(config):
     # Used for dates before Scotty part was gauged, or in the event of missing obs
     parts[2]["FlowFromDiversion"] = parts[2].Diversion * theodosia_from_diversion_only
     theodosia = theodosia.merge(parts[2], how="outer", on="date", sort=True)
-    theodosia["Secondary River Flow"].fillna(
-        theodosia["FlowFromDiversion"], inplace=True
+    theodosia["Secondary River Flow"] = theodosia["Secondary River Flow"].fillna(
+        theodosia["FlowFromDiversion"]
     )
 
     theodosia.drop(

--- a/tests/test_daily_river_flows.py
+++ b/tests/test_daily_river_flows.py
@@ -1445,10 +1445,10 @@ class TestCalcRunoffDataset:
             obs_date, runoff_array, config
         )
 
-        assert len(runoff_ds.dims) == 3
-        assert runoff_ds.dims["time_counter"] == 1
-        assert runoff_ds.dims["y"] == runoff_array.shape[0]
-        assert runoff_ds.dims["x"] == runoff_array.shape[1]
+        assert len(runoff_ds.sizes) == 3
+        assert runoff_ds.sizes["time_counter"] == 1
+        assert runoff_ds.sizes["y"] == runoff_array.shape[0]
+        assert runoff_ds.sizes["x"] == runoff_array.shape[1]
 
     def test_dataset_attrs(self, runoff_array, config, monkeypatch):
         def mock_now(tz):

--- a/tests/test_daily_river_flows.py
+++ b/tests/test_daily_river_flows.py
@@ -108,7 +108,9 @@ class TestReadRiverCSV:
             """
         )
 
-        river_flow = daily_river_flows._read_river_csv(io.StringIO(csv_lines))
+        with pytest.warns(pandas.errors.ParserWarning) as warning_record:
+            # We expect a ParserWarning due to the difference in length of the lines we're parsing
+            river_flow = daily_river_flows._read_river_csv(io.StringIO(csv_lines))
 
         expected = pandas.DataFrame(
             {
@@ -119,6 +121,8 @@ class TestReadRiverCSV:
             }
         )
         pandas.testing.assert_frame_equal(river_flow, expected)
+        expected = "Length of header or names does not match length of data. This leads to a loss of data with index_col=False."
+        assert str(warning_record[0].message) == expected
 
 
 class TestSetDateAsIndex:

--- a/tests/workers/test_get_onc_ferry.py
+++ b/tests/workers/test_get_onc_ferry.py
@@ -246,7 +246,7 @@ class TestResampleNavCoord:
             },
             coords={
                 "sampleTime": pandas.date_range(
-                    start="2021-03-08T10:14:43.082000000", periods=59, freq="1S"
+                    start="2021-03-08T10:14:43.082000000", periods=59, freq="1s"
                 )
             },
             attrs={"station": "TWDP.N1"},

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -1873,10 +1873,10 @@ class TestCalcRunoffDataset:
             obs_date, runoff_array, config
         )
 
-        assert len(runoff_ds.dims) == 3
-        assert runoff_ds.dims["time_counter"] == 1
-        assert runoff_ds.dims["y"] == runoff_array.shape[0]
-        assert runoff_ds.dims["x"] == runoff_array.shape[1]
+        assert len(runoff_ds.sizes) == 3
+        assert runoff_ds.sizes["time_counter"] == 1
+        assert runoff_ds.sizes["y"] == runoff_array.shape[0]
+        assert runoff_ds.sizes["x"] == runoff_array.shape[1]
 
     def test_dataset_attrs(self, runoff_array, config, monkeypatch):
         def mock_now(tz):


### PR DESCRIPTION
Most are `FutureWarning` messages from `pandas` and `xarray`. One is an expected `PArserWarning` from `pandas` that we now capture and inspect.