### PR TITLE
Pin cfgrib package at version 0.9.11.0

### DIFF
--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -28,7 +28,7 @@ dependencies:
   - beautifulsoup4
   - bottleneck
   - cartopy
-  - cfgrib
+  - cfgrib=0.9.11.0
   - click
   - cliff
   - cmocean

--- a/envs/environment-fig-dev.yaml
+++ b/envs/environment-fig-dev.yaml
@@ -25,7 +25,7 @@ dependencies:
   - beautifulsoup4
   - bottleneck
   - cartopy
-  - cfgrib
+  - cfgrib=0.9.11.0
   - cliff
   - cmocean
   - coloredlogs

--- a/envs/environment-linkcheck.yaml
+++ b/envs/environment-linkcheck.yaml
@@ -16,7 +16,7 @@ dependencies:
   - beautifulsoup4
   - bottleneck
   - cartopy
-  - cfgrib
+  - cfgrib=0.9.11.0
   - click
   - cliff
   - cmocean

--- a/envs/environment-prod.yaml
+++ b/envs/environment-prod.yaml
@@ -28,7 +28,7 @@ dependencies:
   - beautifulsoup4
   - bottleneck
   - cartopy
-  - cfgrib
+  - cfgrib=0.9.11.0
   - click
   - cliff
   - cmocean

--- a/envs/environment-test.yaml
+++ b/envs/environment-test.yaml
@@ -16,7 +16,7 @@ dependencies:
   - beautifulsoup4
   - bottleneck
   - cartopy
-  - cfgrib
+  - cfgrib=0.9.11.0
   - click
   - cliff
   - cmocean

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -20,14 +20,14 @@ bcrypt==4.1.3
 beautifulsoup4==4.12.3
 black==24.4.2
 bokeh==3.4.1
-Bottleneck==1.3.8
+Bottleneck==1.4.0
 branca==0.7.2
 Brotli==1.1.0
 cached-property==1.5.2
 Cartopy==0.23.0
 certifi==2024.6.2
 cffi==1.16.0
-cfgrib==0.9.12.0
+cfgrib==0.9.11.0
 cfgv==3.3.1
 cftime==1.6.4
 charset-normalizer==3.3.2
@@ -46,10 +46,10 @@ coverage==7.5.3
 cryptography==42.0.8
 cycler==0.12.1
 cytoolz==0.12.3
-dask==2024.5.2
-dask-expr==1.1.2
+dask==2024.6.0
+dask-expr==1.1.3
 distlib==0.3.8
-distributed==2024.5.2
+distributed==2024.6.0
 docutils==0.20.1
 eccodes==1.7.0
 editables==0.5
@@ -112,7 +112,7 @@ msgpack==1.0.8
 munkres==1.1.4
 mypy-extensions==1.0.0
 nc-time-axis==1.4.1
-netCDF4==1.6.5
+netCDF4==1.7.1
 networkx==3.3
 nodeenv==1.9.1
 numexpr==2.10.0
@@ -201,7 +201,7 @@ supervisor==4.2.5
 sysrsync==1.1.1
 tables==3.9.2
 tblib==3.0.0
-tenacity==8.3.0
+tenacity==8.4.1
 threadpoolctl==3.5.0
 toml==0.10.2
 tomli==2.0.1
@@ -223,7 +223,7 @@ virtualenv==20.26.2
 watchdog==4.0.1
 wcwidth==0.2.13
 wheel==0.43.0
-xarray==2024.5.0
+xarray==2024.6.0
 xyzservices==2024.6.0
 zeep==4.2.1
 zict==3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "beautifulsoup4",
     "bottleneck",
     "cartopy",
-    "cfgrib",
+    "cfgrib == 0.9.11.0",
     "click",
     "cliff",
     "cmocean",


### PR DESCRIPTION
cfgrib 0.9.12.0 introduced support for ecCodes 2.34.0 feature of GRIB files with sub-hourly steps. That appears to result in incorrect values for the `valid_time` variable in the GRIB files produced by the `crop_gribs` worker. This version pin prevents that problem until we can get an upstream resolution.