### PR TITLE
Handle ValueError in get_onc_ctd salinity resampling

### DIFF
--- a/nowcast/workers/get_onc_ctd.py
+++ b/nowcast/workers/get_onc_ctd.py
@@ -99,12 +99,12 @@ def get_onc_ctd(parsed_args, config, *args):
     )
     logger.debug(
         f"filtering ONC {parsed_args.onc_station} temperature data for {ymd} "
-        f"to exlude qaqcFlag!=1"
+        f"to exclude qaqcFlag!=1"
     )
     temperature = _qaqc_filter(ctd_data, "temperature")
     logger.debug(
         f"filtering ONC {parsed_args.onc_station} salinity data for {ymd} "
-        f"to exlude qaqcFlag!=1"
+        f"to exclude qaqcFlag!=1"
     )
     salinity = _qaqc_filter(ctd_data, "salinity")
     logger.debug(f"creating ONC {parsed_args.onc_station} CTD T&S dataset for {ymd}")

--- a/nowcast/workers/get_onc_ctd.py
+++ b/nowcast/workers/get_onc_ctd.py
@@ -176,7 +176,7 @@ def _create_dataset(onc_station, temperature, salinity):
         salinity_mean = salinity.resample(time="15Min").mean()
         salinity_std_dev = salinity.resample(time="15Min").std()
         salinity_sample_count = salinity.resample(time="15Min").count()
-    except IndexError:
+    except (IndexError, ValueError):
         logger.warning(f"no {onc_station} salinity data")
         salinity_mean = temperature_mean.copy()
         salinity_mean.name = "salinity"


### PR DESCRIPTION
xarray version 2023.05.0 introduced a ValueError exception raised when a
DataArray being resampled is empty. We previously handled that condition by
catching an IndexError. Now we catch ValueError too.

The change to ValueError for an empty salinity DataArray didn't show up in
production until the 14jun24 update of the production environment brought xarray
version 2024.06.0 into use.