### PR TITLE
Improve `crop_gribs --backfill` completion log message

### DIFF
--- a/nowcast/workers/crop_gribs.py
+++ b/nowcast/workers/crop_gribs.py
@@ -124,12 +124,15 @@ def crop_gribs(parsed_args, config, *args):
         config,
         msc_var_name,
     )
+    grib_dir = Path(config["weather"]["download"]["2.5 km"]["GRIB dir"])
+    fcst_yyyymmdd = fcst_date.format("YYYYMMDD")
+    grib_fcst_dir = grib_dir / Path(fcst_yyyymmdd, fcst_hr)
 
     if backfill:
         for eccc_grib_file in eccc_grib_files:
             _write_ssc_grib_file(eccc_grib_file, config)
         logger.info(
-            f"finished cropping ECCC grib file to SalishSeaCast subdomain: {eccc_grib_file}"
+            f"finished cropping ECCC grib files to SalishSeaCast subdomain in {grib_fcst_dir}/"
         )
         checklist[fcst_hr] = "cropped to SalishSeaCast subdomain"
         return checklist
@@ -146,9 +149,6 @@ def crop_gribs(parsed_args, config, *args):
 
     handler = _GribFileEventHandler(eccc_grib_files, config)
     observer = watchdog.observers.Observer()
-    grib_dir = Path(config["weather"]["download"]["2.5 km"]["GRIB dir"])
-    fcst_yyyymmdd = fcst_date.format("YYYYMMDD")
-    grib_fcst_dir = grib_dir / Path(fcst_yyyymmdd, fcst_hr)
     observer.schedule(handler, os.fspath(grib_fcst_dir), recursive=True)
     logger.info(f"starting to watch for ECCC grib files to crop in {grib_fcst_dir}/")
     # Create the directory we're going to watch to handle 2 rare situations that can cause

--- a/tests/workers/test_crop_gribs.py
+++ b/tests/workers/test_crop_gribs.py
@@ -345,9 +345,8 @@ class TestCropGribs:
 
         assert caplog.records[1].levelname == "INFO"
         expected = (
-            f"finished cropping ECCC grib file to SalishSeaCast subdomain: "
-            f"forcing/atmospheric/continental2.5/GRIB/20231115/{forecast}/029/"
-            f"20231115T{forecast}Z_MSC_HRDPS_APCP_Sfc_RLatLon0.0225_PT029H.grib2"
+            f"finished cropping ECCC grib files to SalishSeaCast subdomain in "
+            f"forcing/atmospheric/continental2.5/GRIB/20231115/{forecast}/"
         )
         assert caplog.messages[1] == expected
 


### PR DESCRIPTION
The log messages at the completion of the crop_gribs worker with the `--backfill` option has been improved from referring to a specific file to referring to the directory tree containing all the cropped files.