### PR TITLE
Update datetime format in VFPA HADCP observation handling

### DIFF
--- a/nowcast/workers/get_vfpa_hadcp.py
+++ b/nowcast/workers/get_vfpa_hadcp.py
@@ -255,7 +255,7 @@ def _csv_to_dataset(csv_file, place):
             df = df.drop([col], axis="columns")
         except KeyError:
             pass
-    df.index = pandas.to_datetime(df.index, format="%d/%m/%Y %H:%M")
+    df.index = pandas.to_datetime(df.index, format="%Y-%m-%d %H:%M")
     df.index.name = "time"
     df.columns = ("speed", "direction")
     return xarray.Dataset.from_dataframe(df)


### PR DESCRIPTION
The datetime parsing format was adjusted in the VFPA HADCP sensor observation handling module. This change will ensure the timestamp is correctly interpreted as YYYY-MM-DD HH:MM as opposed to the previous format DD/MM/YYYY HH:MM. This change was necessitated by a change in the datetime format in the observation .csv files that was made between 17:00 and 18:00 UTC on 2023-07-02.