### PR TITLE
Update date parsing for river data collection

### DIFF
--- a/nowcast/workers/collect_river_data.py
+++ b/nowcast/workers/collect_river_data.py
@@ -128,7 +128,7 @@ def _calc_eccc_day_avg_discharge(river_name, data_date, config):
         csv_file,
         usecols=["Date", "Discharge / Débit (cms)"],
         index_col="Date",
-        date_parser=lambda x: pandas.to_datetime(x.rpartition("-")[0]),
+        date_format="ISO8601",
     )
     day_avg_discharge = df.loc[f"{data_date.format('YYYY-MM-DD')}"].mean()[
         "Discharge / Débit (cms)"

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -284,7 +284,7 @@ class TestCalcECCC_DayAvgDischarge:
     """Unit test for _calc_eccc_day_avg_discharge() function."""
 
     def test_calc_eccc_day_avg_discharge(self, config, caplog, tmp_path, monkeypatch):
-        def mock_read_csv(csv_file, usecols, index_col, date_parser):
+        def mock_read_csv(csv_file, usecols, index_col, date_format):
             return pandas.DataFrame(
                 numpy.linspace(41.9, 44.1, 290),
                 index=pandas.date_range(


### PR DESCRIPTION
Changed the date_parser to date_format in collect_river_data.py to use ISO8601 date format. Updated corresponding unit test mock in test_collect_river_data.py for consistency. These changes were required due to deprecation of date_parser in pandas=2.0.0.

re: issue #290