### PR TITLE
Update dataset variable dropping method in `make_CHS_currents_file` worker

### DIFF
--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -287,7 +287,7 @@ def _write_netcdf(src_dir, urot5, vrot5, urot10, vrot10, run_type):
     }
 
     filename = src_dir / "CHS_currents.nc"
-    myds.to_netcdf(filename, encoding=encoding, unlimited_dims=("time",))
+    myds.to_netcdf(filename, encoding=encoding, unlimited_dims=("time_counter",))
 
     logger.debug(f"{run_type}: netcdf file written: {filename}")
 

--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -12,8 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""SalishSeaCast worker that average, unstaggers and rotates the near surface velocities,
-and writes them out in an nc file for CHS to use
+"""SalishSeaCast worker that averages, unstaggers and rotates the near surface velocities,
+and writes them out in a netCDF file for CHS to use.
 """
 import logging
 import os

--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -144,9 +144,9 @@ def _read_avg_unstagger_rotate(meshfilename, src_dir, ufile, vfile, run_type):
     """
     :param str meshfilename:
     :param :py:class:`pathlib.Path` src_dir:
-    :param str: ufile:
-    :param str: vfile:
-    :param str: run_type:
+    :param str ufile:
+    :param str vfile:
+    :param str run_type:
 
     :return: 4_tuple of data arrays
                urot5: east velocity averaged over top 5 grid cells
@@ -203,7 +203,7 @@ def _write_netcdf(src_dir, urot5, vrot5, urot10, vrot10, run_type):
     :param :py:class:`xarray.DataArray` vrot5:
     :param :py:class:`xarray.DataArray` urot10:
     :param :py:class:`xarray.DataArray` vrot10:
-    :param str: run_type:
+    :param str run_type:
 
     :return: str CHS_currents_filename
     """

--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -247,7 +247,7 @@ def _write_netcdf(src_dir, urot5, vrot5, urot10, vrot10, run_type):
         "units": "m/s",
     }
 
-    myds = myds.drop("time_centered")
+    myds = myds.drop_vars("time_centered")
     myds = myds.rename({"x": "gridX", "y": "gridY"})
 
     encoding = {

--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -12,8 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""SalishSeaCast worker that average, unstaggers and rotates the near
-surface velocities, and writes them out in an nc file for CHS to use
+"""SalishSeaCast worker that average, unstaggers and rotates the near surface velocities,
+and writes them out in an nc file for CHS to use
 """
 import logging
 import os
@@ -53,6 +53,7 @@ def main():
         help="Date to process the velocities for.",
     )
     worker.run(make_CHS_currents_file, success, failure)
+    return worker
 
 
 def success(parsed_args):

--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -21,8 +21,7 @@ from pathlib import Path
 
 import arrow
 import xarray
-from build.lib.nemo_nowcast.worker import WorkerError
-from nemo_nowcast import NowcastWorker
+from nemo_nowcast import NowcastWorker, WorkerError
 from salishsea_tools import viz_tools
 
 from nowcast import lib

--- a/nowcast/workers/make_CHS_currents_file.py
+++ b/nowcast/workers/make_CHS_currents_file.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import arrow
 import xarray
+from build.lib.nemo_nowcast.worker import WorkerError
 from nemo_nowcast import NowcastWorker
 from salishsea_tools import viz_tools
 
@@ -98,15 +99,18 @@ def make_CHS_currents_file(parsed_args, config, *args):
     """
     run_type = parsed_args.run_type
     run_date = parsed_args.run_date
-    if run_type == "nowcast":
-        start_date = run_date.format("YYYYMMDD")
-        end_date = run_date.format("YYYYMMDD")
-    elif run_type == "forecast":
-        start_date = run_date.shift(days=1).format("YYYYMMDD")
-        end_date = run_date.shift(days=2).format("YYYYMMDD")
-    elif run_type == "forecast2":
-        start_date = run_date.shift(days=2).format("YYYYMMDD")
-        end_date = run_date.shift(days=3).format("YYYYMMDD")
+    match run_type:
+        case "nowcast":
+            start_date = run_date.format("YYYYMMDD")
+            end_date = run_date.format("YYYYMMDD")
+        case "forecast":
+            start_date = run_date.shift(days=1).format("YYYYMMDD")
+            end_date = run_date.shift(days=2).format("YYYYMMDD")
+        case "forecast2":
+            start_date = run_date.shift(days=2).format("YYYYMMDD")
+            end_date = run_date.shift(days=3).format("YYYYMMDD")
+        case _:
+            raise WorkerError(f"unexpected run type: {run_type}")
 
     grid_dir = Path(config["figures"]["grid dir"])
     meshfilename = grid_dir / config["run types"][run_type]["mesh mask"]

--- a/tests/workers/test_make_CHS_currents_file.py
+++ b/tests/workers/test_make_CHS_currents_file.py
@@ -193,13 +193,20 @@ class TestFailure:
     "nowcast.workers.make_CHS_currents_file._write_netcdf",
     spec=make_CHS_currents_file._write_netcdf,
 )
-@patch("nowcast.workers.make_CHS_currents_file.lib.fix_perms", autospec=True)
 class TestMakeCHSCurrentsFile:
     """Unit tests for make_CHS_currents_function."""
 
+    @staticmethod
+    @pytest.fixture
+    def mock_fix_perms(monkeypatch):
+        def _mock_fix_perms(path, grp_name):
+            pass
+
+        monkeypatch.setattr(make_CHS_currents_file.lib, "fix_perms", _mock_fix_perms)
+
     @pytest.mark.parametrize("run_type", ["nowcast", "forecast", "forecast2"])
     def test_checklist(
-        self, m_fix_perms, m_write_ncdf, m_read_aur, run_type, config, caplog
+        self, m_write_ncdf, m_read_aur, mock_fix_perms, run_type, config, caplog
     ):
         parsed_args = SimpleNamespace(
             run_type=run_type, run_date=arrow.get("2018-09-01")
@@ -233,9 +240,9 @@ class TestMakeCHSCurrentsFile:
     )
     def test_read_avg_unstagger_rotatehecklist(
         self,
-        m_fix_perms,
         m_write_ncdf,
         m_read_aur,
+        mock_fix_perms,
         run_type,
         results_archive,
         ufile,

--- a/tests/workers/test_make_CHS_currents_file.py
+++ b/tests/workers/test_make_CHS_currents_file.py
@@ -21,7 +21,7 @@
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import arrow
 import nemo_nowcast
@@ -64,47 +64,39 @@ def config(base_config):
     return config_
 
 
-@patch("nowcast.workers.make_CHS_currents_file.NowcastWorker", spec=True)
+@pytest.fixture
+def mock_worker(mock_nowcast_worker, monkeypatch):
+    monkeypatch.setattr(make_CHS_currents_file, "NowcastWorker", mock_nowcast_worker)
+
+
 class TestMain:
     """Unit tests for main() function."""
 
-    def test_instantiate_worker(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_CHS_currents_file.main()
-        args, kwargs = m_worker.call_args
-        assert args == ("make_CHS_currents_file",)
-        assert list(kwargs.keys()) == ["description"]
-
-    def test_init_cli(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_CHS_currents_file.main()
-        m_worker().init_cli.assert_called_once_with()
-
-    def test_add_run_type_arg(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_CHS_currents_file.main()
-        args, kwargs = m_worker().cli.add_argument.call_args_list[0]
-        assert args == ("run_type",)
-        assert kwargs["choices"] == {"nowcast", "forecast", "forecast2"}
-        assert "help" in kwargs
-
-    def test_add_run_date_option(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_CHS_currents_file.main()
-        args, kwargs = m_worker().cli.add_date_option.call_args_list[0]
-        assert args == ("--run-date",)
-        assert kwargs["default"] == arrow.now().floor("day")
-        assert "help" in kwargs
-
-    def test_run_worker(self, m_worker):
-        m_worker().cli = Mock(name="cli")
-        make_CHS_currents_file.main()
-        args, kwargs = m_worker().run.call_args
-        assert args == (
-            make_CHS_currents_file.make_CHS_currents_file,
-            make_CHS_currents_file.success,
-            make_CHS_currents_file.failure,
+    def test_instantiate_worker(self, mock_worker):
+        worker = make_CHS_currents_file.main()
+        assert worker.name == "make_CHS_currents_file"
+        assert worker.description.startswith(
+            "SalishSeaCast worker that average, unstaggers and rotates the near surface velocities,"
         )
+
+    def test_add_run_type_arg(self, mock_worker):
+        worker = make_CHS_currents_file.main()
+        assert worker.cli.parser._actions[3].dest == "run_type"
+        assert worker.cli.parser._actions[3].choices == {
+            "nowcast",
+            "forecast",
+            "forecast2",
+        }
+        assert worker.cli.parser._actions[3].help
+
+    def test_add_run_date_option(self, mock_worker):
+        worker = make_CHS_currents_file.main()
+        assert worker.cli.parser._actions[4].dest == "run_date"
+        expected = nemo_nowcast.cli.CommandLineInterface.arrow_date
+        assert worker.cli.parser._actions[4].type == expected
+        expected = arrow.now().floor("day")
+        assert worker.cli.parser._actions[4].default == expected
+        assert worker.cli.parser._actions[4].help
 
 
 class TestConfig:

--- a/tests/workers/test_make_CHS_currents_file.py
+++ b/tests/workers/test_make_CHS_currents_file.py
@@ -76,7 +76,7 @@ class TestMain:
         worker = make_CHS_currents_file.main()
         assert worker.name == "make_CHS_currents_file"
         assert worker.description.startswith(
-            "SalishSeaCast worker that average, unstaggers and rotates the near surface velocities,"
+            "SalishSeaCast worker that averages, unstaggers and rotates the near surface velocities,"
         )
 
     def test_add_run_type_arg(self, mock_worker):


### PR DESCRIPTION
re: xarray DeprecationWarning (see issue #291).

Also:
* corrected the name of the unlimited dimension in the netCDF file
* modernized the test suite to use pytest fixtures instead of unit tests patch and mock
* fixed typos in docstring type definitions