### PR TITLE
Add month-averaging of grazing/mortality & biology growth rate variable groups to `make_averaged_dataset`

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -442,6 +442,12 @@ averaged datasets:
     chemistry:
       reshapr config: month-average_202111_chemistry.yaml
       file pattern: "SalishSeaCast_1m_chem_T_{yyyymmdd}_{yyyymmdd}.nc"
+    grazing:
+      reshapr config: month-average_202111_grazing_mortality.yaml
+      file pattern: "SalishSeaCast_1m_graz_T_{yyyymmdd}_{yyyymmdd}.nc"
+    growth:
+      reshapr config: month-average_202111_bio_growth_rates.yaml
+      file pattern: "SalishSeaCast_1m_prod_T_{yyyymmdd}_{yyyymmdd}.nc"
     physics:
       reshapr config: month-average_202111_physics.yaml
       file pattern: "SalishSeaCast_1m_grid_T_{yyyymmdd}_{yyyymmdd}.nc"
@@ -1587,6 +1593,10 @@ message registry:
       failure month biology: biology dataset month-averaging failed
       success month chemistry: chemistry dataset month-averaged
       failure month chemistry: chemistry dataset month-averaging failed
+      success month grazing: grazing dataset month-averaged
+      failure month grazing: grazing dataset month-averaging failed
+      success month growth: biology growth rates dataset month-averaged
+      failure month growth: biology growth rates dataset month-averaging failed
       success month physics: physics dataset month-averaged
       failure month physics: physics dataset month-averaging failed
       crash: make_averaged_dataset worker crashed

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -1587,6 +1587,8 @@ message registry:
       failure day biology: biology dataset day-averaging failed
       success day chemistry: chemistry dataset day-averaged
       failure day chemistry: chemistry dataset day-averaging failed
+      failure day grazing: grazing dataset day-averaging failed
+      failure day growth: growth dataset day-averaging failed
       success day physics: physics dataset day-averaged
       failure day physics: physics dataset day-averaging failed
       success month biology: biology dataset month-averaged

--- a/config/reshapr/month-average_202111_bio_growth_rates.yaml
+++ b/config/reshapr/month-average_202111_bio_growth_rates.yaml
@@ -1,0 +1,32 @@
+# `reshapr extract` config to resample v202111 day-average grzing & mortality fields
+# to month-average
+
+dataset:
+  model profile: SalishSeaCast-202111-salish.yaml
+  time base: day
+  variables group: biology growth rates
+
+dask cluster: tcp://142.103.36.12:4386
+
+# Placeholder state/end dates that are overridden by worker's run-date arg
+start date: 2007-01-01
+end date: 2007-01-31
+
+extract variables:
+  - PPDIAT
+  - PPPHY
+  - PPDIATNO3
+  - PPPHYNO3
+  - TQ10
+
+resample:
+  time interval: 1M
+  aggregation: mean
+
+extracted dataset:
+  name: SalishSeaCast_1m_prod_T
+  description: Month-averaged biology growth rate variables resampled from
+               v202111 SalishSea_1d_*_prod_T.nc
+  deflate: True
+  format: NETCDF4
+  dest dir: /results2/SalishSea/month-avg.202111/

--- a/config/reshapr/month-average_202111_grazing_mortality.yaml
+++ b/config/reshapr/month-average_202111_grazing_mortality.yaml
@@ -1,0 +1,38 @@
+# `reshapr extract` config to resample v202111 day-average grzing & mortality fields
+# to month-average
+
+dataset:
+  model profile: SalishSeaCast-202111-salish.yaml
+  time base: day
+  variables group: grazing
+
+dask cluster: tcp://142.103.36.12:4386
+
+# Placeholder state/end dates that are overridden by worker's run-date arg
+start date: 2007-01-01
+end date: 2007-01-31
+
+extract variables:
+  - MORTPHY
+  - MORTDIAT
+  - MORTMICZ
+  - GRMESZDIAT
+  - GRMESZPHY
+  - GRMESZPON
+  - GRMESZMICZ
+  - GRMICZDIAT
+  - GRMICZPHY
+  - GRMICZPON
+  - GRMICZMICZ
+
+resample:
+  time interval: 1M
+  aggregation: mean
+
+extracted dataset:
+  name: SalishSeaCast_1m_graz_T
+  description: Month-averaged grazing and mortality variables resampled from
+               v202111 SalishSea_1d_*_graz_T.nc
+  deflate: True
+  format: NETCDF4
+  dest dir: /results2/SalishSea/month-avg.202111/

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1557,6 +1557,8 @@ def after_make_averaged_dataset(msg, config, checklist):
         "crash": [],
         "failure day biology": [],
         "failure day chemistry": [],
+        "failure day grazing": [],
+        "failure day growth": [],
         "failure day physics": [],
         "failure month biology": [],
         "failure month chemistry": [],
@@ -1566,6 +1568,8 @@ def after_make_averaged_dataset(msg, config, checklist):
         "success day physics": [],
         "success month biology": [],
         "success month chemistry": [],
+        "success month grazing": [],
+        "success month growth": [],
         "success month physics": [],
     }
     if msg.type.startswith("success day"):
@@ -1580,6 +1584,33 @@ def after_make_averaged_dataset(msg, config, checklist):
                     host="localhost",
                 )
             )
+    if msg.type.startswith("success month"):
+        *_, reshapr_var_group = msg.type.split()
+        match reshapr_var_group:
+            case "physics":
+                run_date = arrow.get(msg.payload["month physics"]["run date"]).format(
+                    "YYYY-MM-DD"
+                )
+                next_workers[msg.type].append(
+                    NextWorker(
+                        "nowcast.workers.make_averaged_dataset",
+                        args=["month", "grazing", "--run-date", run_date],
+                        host="localhost",
+                    )
+                )
+            case "grazing":
+                run_date = arrow.get(msg.payload["month grazing"]["run date"]).format(
+                    "YYYY-MM-DD"
+                )
+                next_workers[msg.type].append(
+                    NextWorker(
+                        "nowcast.workers.make_averaged_dataset",
+                        args=["month", "growth", "--run-date", run_date],
+                        host="localhost",
+                    )
+                )
+            case _:
+                pass
     return next_workers[msg.type]
 
 

--- a/nowcast/workers/make_averaged_dataset.py
+++ b/nowcast/workers/make_averaged_dataset.py
@@ -54,7 +54,7 @@ def main():
     )
     worker.cli.add_argument(
         "reshapr_var_group",
-        choices={"biology", "chemistry", "physics"},
+        choices={"biology", "chemistry", "grazing", "growth", "physics"},
         help="Dataset variable group to run extraction for",
     )
     worker.cli.add_date_option(
@@ -152,6 +152,12 @@ def make_averaged_dataset(parsed_args, config, *args):
         logger.error(
             f"Month-averaging must start on the first day of a month but "
             f"run_date = {run_date.format('YYYY-MM-DD')}"
+        )
+        raise WorkerError
+    if avg_time_interval == "day" and reshapr_var_group in {"grazing", "growth"}:
+        logger.error(
+            f"Day-average {reshapr_var_group} datasets are calculated by NEMO; "
+            f"use this worker for month-averaging"
         )
         raise WorkerError
     reshapr_config_dir = Path(config["averaged datasets"]["reshapr config dir"])

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2216,10 +2216,12 @@ class TestAfterMakeAveragedDataset:
             "crash",
             "failure day biology",
             "failure day chemistry",
+            "failure day grazing",
+            "failure day growth",
             "failure day physics",
             "success month biology",
             "success month chemistry",
-            "success month physics",
+            "success month growth",
             "failure month biology",
             "failure month chemistry",
             "failure month physics",
@@ -2257,6 +2259,44 @@ class TestAfterMakeAveragedDataset:
         expected = NextWorker(
             "nowcast.workers.make_averaged_dataset",
             args=["month", reshapr_var_group, "--run-date", "2024-02-01"],
+            host="localhost",
+        )
+        assert expected in workers
+
+    def test_month_physics_success_launch_month_grazing(self, config, checklist):
+        msg = Message(
+            "make_averaged_dataset",
+            "success month physics",
+            payload={
+                "month physics": {
+                    "run date": "2024-09-01",
+                    "file path": "SalishSea_1m_20240901_20240930_grid_T.nc",
+                }
+            },
+        )
+        workers = next_workers.after_make_averaged_dataset(msg, config, checklist)
+        expected = NextWorker(
+            "nowcast.workers.make_averaged_dataset",
+            args=["month", "grazing", "--run-date", "2024-09-01"],
+            host="localhost",
+        )
+        assert expected in workers
+
+    def test_month_grazing_success_launch_month_growth(self, config, checklist):
+        msg = Message(
+            "make_averaged_dataset",
+            "success month grazing",
+            payload={
+                "month grazing": {
+                    "run date": "2024-09-01",
+                    "file path": "SalishSea_1m_20240901_20240930_graz_T.nc",
+                }
+            },
+        )
+        workers = next_workers.after_make_averaged_dataset(msg, config, checklist)
+        expected = NextWorker(
+            "nowcast.workers.make_averaged_dataset",
+            args=["month", "growth", "--run-date", "2024-09-01"],
             host="localhost",
         )
         assert expected in workers

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -144,6 +144,8 @@ class TestConfig:
             "failure day biology",
             "success day chemistry",
             "failure day chemistry",
+            "failure day grazing",
+            "failure day growth",
             "success day physics",
             "failure day physics",
             "success month biology",

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -59,6 +59,12 @@ def config(base_config):
                     chemistry:
                       reshapr config: month-average_202111_chemistry.yaml
                       file pattern: "SalishSeaCast_1m_chem_T_{yyyymmdd}_{yyyymmdd}.nc"
+                    grazing:
+                      reshapr config: month-average_202111_grazing_mortality.yaml
+                      file pattern: "SalishSeaCast_1m_graz_T_{yyyymmdd}_{yyyymmdd}.nc"
+                    growth:
+                      reshapr config: month-average_202111_bio_growth_rates.yaml
+                      file pattern: "SalishSeaCast_1m_prod_T_{yyyymmdd}_{yyyymmdd}.nc"
                     physics:
                       reshapr config: month-average_202111_physics.yaml
                       file pattern: "SalishSeaCast_1m_grid_T_{yyyymmdd}_{yyyymmdd}.nc"
@@ -100,6 +106,8 @@ class TestMain:
         assert worker.cli.parser._actions[4].choices == {
             "biology",
             "chemistry",
+            "grazing",
+            "growth",
             "physics",
         }
         assert worker.cli.parser._actions[4].help
@@ -142,12 +150,16 @@ class TestConfig:
             "failure month biology",
             "success month chemistry",
             "failure month chemistry",
+            "success month grazing",
+            "failure month grazing",
+            "success month growth",
+            "failure month growth",
             "success month physics",
             "failure month physics",
             "crash",
         ]
 
-    def test_averaged_datasets(self, prod_config):
+    def test_reshapr_configs(self, prod_config):
         averaged_datasets = prod_config["averaged datasets"]
         expected = "/SalishSeaCast/SalishSeaNowcast/config/reshapr/"
 
@@ -195,6 +207,16 @@ class TestConfig:
                 "chemistry",
                 "month-average_202111_chemistry.yaml",
                 "SalishSeaCast_1m_chem_T_{yyyymmdd}_{yyyymmdd}.nc",
+            ),
+            (
+                "grazing",
+                "month-average_202111_grazing_mortality.yaml",
+                "SalishSeaCast_1m_graz_T_{yyyymmdd}_{yyyymmdd}.nc",
+            ),
+            (
+                "growth",
+                "month-average_202111_bio_growth_rates.yaml",
+                "SalishSeaCast_1m_prod_T_{yyyymmdd}_{yyyymmdd}.nc",
             ),
             (
                 "physics",
@@ -247,6 +269,8 @@ class TestSuccess:
         (
             ("month", "biology"),
             ("month", "chemistry"),
+            ("month", "grazing"),
+            ("month", "growth"),
             ("month", "physics"),
         ),
     )
@@ -301,6 +325,8 @@ class TestFailure:
         (
             ("month", "biology"),
             ("month", "chemistry"),
+            ("month", "grazing"),
+            ("month", "growth"),
             ("month", "physics"),
         ),
     )
@@ -385,6 +411,8 @@ class TestMakeAveragedDataset:
         (
             ("month", "biology"),
             ("month", "chemistry"),
+            ("month", "grazing"),
+            ("month", "growth"),
             ("month", "physics"),
         ),
     )
@@ -445,4 +473,23 @@ class TestMakeAveragedDataset:
 
         assert caplog.records[0].levelname == "ERROR"
         expected = f"Month-averaging must start on the first day of a month but run_date = 2022-11-10"
+        assert caplog.messages[0] == expected
+
+    @pytest.mark.parametrize("reshapr_var_group", ("grazing", "growth"))
+    def test_month_avg_only_var_groups(self, reshapr_var_group, caplog, config):
+        parsed_args = SimpleNamespace(
+            avg_time_interval="day",
+            run_date=arrow.get("2024-09-24"),
+            reshapr_var_group=reshapr_var_group,
+        )
+        caplog.set_level(logging.DEBUG)
+
+        with pytest.raises(WorkerError):
+            make_averaged_dataset.make_averaged_dataset(parsed_args, config)
+
+        assert caplog.records[0].levelname == "ERROR"
+        expected = (
+            f"Day-average {reshapr_var_group} datasets are calculated by NEMO; "
+            f"use this worker for month-averaging"
+        )
         assert caplog.messages[0] == expected


### PR DESCRIPTION
- extraction config YAML files for Reshapr
- `grazing` and `growth` options for `reshapr_var_group`  command-line argument
- code to prevent redundant calculation of day-average datasets that NEMO produces for `grazing` and `growth`
- automatic calculation of `grazing` and `growth` month-average datasets at the end of each month
- test suite updates