### PR TITLE
Add new subtopic pattern for datamart directory structure change

### DIFF
--- a/config/supervisord.ini
+++ b/config/supervisord.ini
@@ -44,7 +44,7 @@ autorestart = true
 
 [program:sr_subscribe-hrdps-continental]
 # Use `sr_subscribe foreground` instead of `start` to enable supervisor to manage the process
-command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hrdps-continental-dd-weather.conf
+command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hrdps-continental-hpfx.conf
 # sr_subscribe logs to stderr; redirect that to stdout so that we can
 # view the sr_subscribe log with `supervisorctl tail sr_subscribe-hrdps-continental`
 redirect_stderr = true
@@ -53,7 +53,7 @@ autorestart = true
 
 [program:sr_subscribe-hydrometric]
 # Use `sr_subscribe foreground` instead of `start` to enable supervisor to manage the process
-command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hydrometric-dd-weather.conf
+command = %(ENV_SARRACENIA_ENV)s/bin/sr_subscribe foreground %(ENV_SARRACENIA_CONFIG)s/hydrometric-hpfx.conf
 # sr_subscribe logs to stderr; redirect that to stdout so that we can
 # view the sr_subscribe log with `supervisorctl tail sr_subscribe-hydrometric`
 redirect_stderr = true

--- a/sarracenia/hrdps-continental-dd-weather.conf
+++ b/sarracenia/hrdps-continental-dd-weather.conf
@@ -3,7 +3,6 @@ queue_name q_anonymous.sr_subscribe.hrdps-continental-dd-weather.UBC.SalishSeaCa
 instances 1
 expire 6h
 
-subtopic model_hrdps.continental.2.5km.#
 subtopic *.WXO-DD.model_hrdps.continental.2.5km.#
 directory /SalishSeaCast/datamart/hrdps-continental/
 # mirror the datamart directory structure but drop the 1st 4 path elements

--- a/sarracenia/hrdps-continental-dd-weather.conf
+++ b/sarracenia/hrdps-continental-dd-weather.conf
@@ -4,6 +4,7 @@ instances 1
 expire 6h
 
 subtopic model_hrdps.continental.2.5km.#
+subtopic *.WXO-DD.model_hrdps.continental.2.5km.#
 directory /SalishSeaCast/datamart/hrdps-continental/
 # mirror the datamart directory structure but drop the 1st 4 path elements
 # so that our mirror starts with forecast number (00/, 06/, 12/, or 18/)

--- a/sarracenia/hydrometric-dd-weather.conf
+++ b/sarracenia/hydrometric-dd-weather.conf
@@ -4,7 +4,6 @@ instances 1
 expire 1h
 
 subtopic *.WXO-DD.hydrometric.csv.BC.hourly
-subtopic hydrometric.csv.BC.hourly
 directory /SalishSeaCast/datamart/hydrometric
 overwrite true
 # Capilano River above dam intake

--- a/sarracenia/hydrometric-dd-weather.conf
+++ b/sarracenia/hydrometric-dd-weather.conf
@@ -3,6 +3,7 @@ queue_name q_anonymous.sr_subscribe.hydrometric-dd-weather.UBC.SalishSeaCast
 instances 1
 expire 1h
 
+subtopic *.WXO-DD.hydrometric.csv.BC.hourly
 subtopic hydrometric.csv.BC.hourly
 directory /SalishSeaCast/datamart/hydrometric
 overwrite true


### PR DESCRIPTION
- Updated `hrdps-continental-dd-weather.conf` to include a new subtopic pattern in anticipation of the ~27-Nov-2024~ 4-Dec-2024 change in the directory structure on the dd.weather.gc.ca server.
- The new pattern aligns with that of the hpfx.collab.science.gc.ca server to prevent any interruption during the transition.
- After the directory structure change, the `model_hrdps.continental.2.5km.#` subtopic can be safely removed.