### PR TITLE
Disable uploads to `graham` during 7dec24 to 28feb25 downtime

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -707,19 +707,19 @@ run:
         Fraser turbidity dir: /home/sallen/MEOPAR/rivers/river_turb/
         weather dir: /home/sallen/MEOPAR/continental2.5/NEMO-atmos/
 
-    robot.graham:
-      ssh key: SalishSeaCast_robot.graham_ed25519
-      shared storage: False
-      make forcing links: False
-      # Empty collection of run types because all we want to do is upload daily forcing
-      # files
-      run types: {}
-      forcing:
-        ssh dir: /project/def-allen/SalishSea/forcing/sshNeahBay/
-        bc dir: /project/def-allen/SalishSea/forcing/LiveOcean/
-        rivers dir: /project/def-allen/SalishSea/forcing/rivers/
-        Fraser turbidity dir: /project/def-allen/SalishSea/forcing/rivers/river_turb/
-        weather dir: /project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/
+#    robot.graham:
+#      ssh key: SalishSeaCast_robot.graham_ed25519
+#      shared storage: False
+#      make forcing links: False
+#      # Empty collection of run types because all we want to do is upload daily forcing
+#      # files
+#      run types: {}
+#      forcing:
+#        ssh dir: /project/def-allen/SalishSea/forcing/sshNeahBay/
+#        bc dir: /project/def-allen/SalishSea/forcing/LiveOcean/
+#        rivers dir: /project/def-allen/SalishSea/forcing/rivers/
+#        Fraser turbidity dir: /project/def-allen/SalishSea/forcing/rivers/river_turb/
+#        weather dir: /project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/
 
     optimum-hindcast:
       ssh key: SalishSeaNEMO-nowcast_id_rsa

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1699,14 +1699,14 @@ def after_split_results(msg, config, checklist):
     if msg.type.startswith("success"):
         if config["results tarballs"]["archive hindcast"]:
             last_date = max(map(arrow.get, msg.payload))
-            if arrow.get(last_date).shift(days=+1).day == 1:
-                yyyymmm = arrow.get(last_date).format("YYYY-MMM").lower()
-                next_workers[msg.type].append(
-                    NextWorker(
-                        "nowcast.workers.archive_tarball",
-                        args=["hindcast", yyyymmm, "robot.graham"],
-                    )
-                )
+            # if arrow.get(last_date).shift(days=+1).day == 1:
+            #     yyyymmm = arrow.get(last_date).format("YYYY-MMM").lower()
+            #     next_workers[msg.type].append(
+            #         NextWorker(
+            #             "nowcast.workers.archive_tarball",
+            #             args=["hindcast", yyyymmm, "robot.graham"],
+            #         )
+            #     )
     return next_workers[msg.type]
 
 

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1517,14 +1517,14 @@ def after_download_results(msg, config, checklist):
                             args=["day", var_group, "--run-date", run_date],
                         )
                     )
-                if arrow.get(run_date).shift(days=+1).day == 1:
-                    yyyymmm = arrow.get(run_date).format("YYYY-MMM").lower()
-                    next_workers[msg.type].append(
-                        NextWorker(
-                            "nowcast.workers.archive_tarball",
-                            args=["nowcast-green", yyyymmm, "robot.graham"],
-                        )
-                    )
+                # if arrow.get(run_date).shift(days=+1).day == 1:
+                #     yyyymmm = arrow.get(run_date).format("YYYY-MMM").lower()
+                #     next_workers[msg.type].append(
+                #         NextWorker(
+                #             "nowcast.workers.archive_tarball",
+                #             args=["nowcast-green", yyyymmm, "robot.graham"],
+                #         )
+                #     )
                 return next_workers[msg.type]
         if run_type.startswith("forecast"):
             next_workers[msg.type].append(

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2400,31 +2400,31 @@ class TestAfterSplitResults:
         )
         assert archive_tarball not in workers
 
-    def test_success_archive_hindcast_monthend_launch_archive_tarball_hindcast(
-        self, config, checklist, monkeypatch
-    ):
-        monkeypatch.setitem(config["results tarballs"], "archive hindcast", True)
-        workers = next_workers.after_split_results(
-            Message(
-                "split_results",
-                "success hindcast",
-                payload={
-                    "2022-10-26",
-                    "2022-10-27",
-                    "2022-10-28",
-                    "2022-10-29",
-                    "2022-10-30",
-                    "2022-10-31",
-                },
-            ),
-            config,
-            checklist,
-        )
-        expected = NextWorker(
-            "nowcast.workers.archive_tarball",
-            args=["hindcast", "2022-oct", "robot.graham"],
-        )
-        assert workers[-1] == expected
+    # def test_success_archive_hindcast_monthend_launch_archive_tarball_hindcast(
+    #     self, config, checklist, monkeypatch
+    # ):
+    #     monkeypatch.setitem(config["results tarballs"], "archive hindcast", True)
+    #     workers = next_workers.after_split_results(
+    #         Message(
+    #             "split_results",
+    #             "success hindcast",
+    #             payload={
+    #                 "2022-10-26",
+    #                 "2022-10-27",
+    #                 "2022-10-28",
+    #                 "2022-10-29",
+    #                 "2022-10-30",
+    #                 "2022-10-31",
+    #             },
+    #         ),
+    #         config,
+    #         checklist,
+    #     )
+    #     expected = NextWorker(
+    #         "nowcast.workers.archive_tarball",
+    #         args=["hindcast", "2022-oct", "robot.graham"],
+    #     )
+    #     assert workers[-1] == expected
 
     def test_success_archive_hindcast_not_monthend_launch_archive_tarball_hindcast(
         self, config, checklist, monkeypatch

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -2137,24 +2137,24 @@ class TestAfterDownloadResults:
         )
         assert archive_tarball not in workers
 
-    def test_success_nowcast_green_monthend_launch_archive_tarball(
-        self, config, checklist
-    ):
-        workers = next_workers.after_download_results(
-            Message(
-                "download_results",
-                "success nowcast-green",
-                payload={"nowcast-green": {"run date": "2022-05-31"}},
-            ),
-            config,
-            checklist,
-        )
-        expected = NextWorker(
-            "nowcast.workers.archive_tarball",
-            args=["nowcast-green", "2022-may", "robot.graham"],
-            host="localhost",
-        )
-        assert expected in workers
+    # def test_success_nowcast_green_monthend_launch_archive_tarball(
+    #     self, config, checklist
+    # ):
+    #     workers = next_workers.after_download_results(
+    #         Message(
+    #             "download_results",
+    #             "success nowcast-green",
+    #             payload={"nowcast-green": {"run date": "2022-05-31"}},
+    #         ),
+    #         config,
+    #         checklist,
+    #     )
+    #     expected = NextWorker(
+    #         "nowcast.workers.archive_tarball",
+    #         args=["nowcast-green", "2022-may", "robot.graham"],
+    #         host="localhost",
+    #     )
+    #     assert expected in workers
 
     @pytest.mark.parametrize(
         "run_type, run_date",

--- a/tests/workers/test_download_results.py
+++ b/tests/workers/test_download_results.py
@@ -68,8 +68,8 @@ def config(base_config):
                       run types:
                         nowcast-agrif:
                           results: SalishSea/nowcast-agrif/
-                    robot.graham:
-                      ssh key: SalishSeaNEMO-nowcast_id_rsa
+                    # robot.graham:
+                    #   ssh key: SalishSeaNEMO-nowcast_id_rsa
 
                   hindcast hosts:
                       optimum-hindcast:
@@ -175,7 +175,7 @@ class TestConfig:
             "arbutus.cloud-nowcast",
             "salish-nowcast",
             "orcinus-nowcast-agrif",
-            "robot.graham",
+            # "robot.graham",
             "optimum-hindcast",
         ]
 
@@ -187,7 +187,7 @@ class TestConfig:
                 ["nowcast", "forecast", "forecast2", "nowcast-green"],
             ),
             ("orcinus-nowcast-agrif", ["nowcast-agrif"]),
-            ("robot.graham", []),
+            # ("robot.graham", []),
             ("optimum-hindcast", []),
         ),
     )
@@ -459,7 +459,10 @@ class TestDownloadResults:
 
     @pytest.mark.parametrize(
         "host_name, dest_host",
-        (("optimum-hindcast", "localhost"), ("sockeye-hindcast", "robot.graham")),
+        (
+            ("optimum-hindcast", "localhost"),
+            ("sockeye-hindcast", "robot.graham"),
+        ),
     )
     def test_hindcast_not_unlink_fvcom_boundary_files(
         self,

--- a/tests/workers/test_make_forcing_links.py
+++ b/tests/workers/test_make_forcing_links.py
@@ -146,7 +146,7 @@ class TestConfig:
             "arbutus.cloud-nowcast",
             "salish-nowcast",
             "orcinus-nowcast-agrif",
-            "robot.graham",
+            # "robot.graham",
             "optimum-hindcast",
         ]
 
@@ -155,7 +155,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "SalishSeaNEMO-nowcast_id_rsa"),
             ("orcinus-nowcast-agrif", "SalishSeaNEMO-nowcast_id_rsa"),
-            ("robot.graham", "SalishSeaCast_robot.graham_ed25519"),
+            # ("robot.graham", "SalishSeaCast_robot.graham_ed25519"),
             ("optimum-hindcast", "SalishSeaNEMO-nowcast_id_rsa"),
         ),
     )
@@ -180,7 +180,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/sshNeahBay/"),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/sshNeahBay/"),
-            ("robot.graham", "/project/def-allen/SalishSea/forcing/sshNeahBay/"),
+            # ("robot.graham", "/project/def-allen/SalishSea/forcing/sshNeahBay/"),
             (
                 "optimum-hindcast",
                 "/data/sallen/shared/SalishSeaCast/forcing/sshNeahBay/",
@@ -203,7 +203,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/rivers/"),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/rivers/"),
-            ("robot.graham", "/project/def-allen/SalishSea/forcing/rivers/"),
+            # ("robot.graham", "/project/def-allen/SalishSea/forcing/rivers/"),
             ("optimum-hindcast", "/data/sallen/shared/SalishSeaCast/forcing/rivers/"),
         ),
     )
@@ -218,10 +218,10 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/rivers/river_turb/"),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/rivers/river_turb/"),
-            (
-                "robot.graham",
-                "/project/def-allen/SalishSea/forcing/rivers/river_turb/",
-            ),
+            # (
+            #     "robot.graham",
+            #     "/project/def-allen/SalishSea/forcing/rivers/river_turb/",
+            # ),
             (
                 "optimum-hindcast",
                 "/data/sallen/shared/SalishSeaCast/forcing/rivers/river_turb/",
@@ -248,10 +248,10 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/GEM2.5/ops/NEMO-atmos/"),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/continental2.5/NEMO-atmos/"),
-            (
-                "robot.graham",
-                "/project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
-            ),
+            # (
+            #     "robot.graham",
+            #     "/project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
+            # ),
             (
                 "optimum-hindcast",
                 "/data/sallen/shared/SalishSeaCast/forcing/atmospheric/continental2.5/nemo_forcing/",
@@ -275,7 +275,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/LiveOcean/"),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/LiveOcean/"),
-            ("robot.graham", "/project/def-allen/SalishSea/forcing/LiveOcean/"),
+            # ("robot.graham", "/project/def-allen/SalishSea/forcing/LiveOcean/"),
             (
                 "optimum-hindcast",
                 "/data/sallen/shared/SalishSeaCast/forcing/LiveOcean/",

--- a/tests/workers/test_upload_forcing.py
+++ b/tests/workers/test_upload_forcing.py
@@ -140,7 +140,7 @@ class TestConfig:
             "arbutus.cloud-nowcast",
             "salish-nowcast",
             "orcinus-nowcast-agrif",
-            "robot.graham",
+            # "robot.graham",
             "optimum-hindcast",
         ]
 
@@ -150,9 +150,9 @@ class TestConfig:
                 ssh_key = prod_config["run"]["enabled hosts"][host]["ssh key"]
                 assert ssh_key == "SalishSeaNEMO-nowcast_id_rsa"
 
-    def test_robot_graham_ssh_key(self, prod_config):
-        ssh_key = prod_config["run"]["enabled hosts"]["robot.graham"]["ssh key"]
-        assert ssh_key == "SalishSeaCast_robot.graham_ed25519"
+    # def test_robot_graham_ssh_key(self, prod_config):
+    #     ssh_key = prod_config["run"]["enabled hosts"]["robot.graham"]["ssh key"]
+    #     assert ssh_key == "SalishSeaCast_robot.graham_ed25519"
 
     @pytest.mark.parametrize(
         "host, ssh_key",
@@ -163,7 +163,7 @@ class TestConfig:
                 "/data/sallen/shared/SalishSeaCast/forcing/sshNeahBay/",
             ),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/sshNeahBay/"),
-            ("robot.graham", "/project/def-allen/SalishSea/forcing/sshNeahBay/"),
+            # ("robot.graham", "/project/def-allen/SalishSea/forcing/sshNeahBay/"),
         ),
     )
     def test_ssh_uploads(self, host, ssh_key, prod_config):
@@ -180,10 +180,10 @@ class TestConfig:
                 "/data/sallen/shared/SalishSeaCast/forcing/rivers/river_turb/",
             ),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/rivers/river_turb/"),
-            (
-                "robot.graham",
-                "/project/def-allen/SalishSea/forcing/rivers/river_turb/",
-            ),
+            # (
+            #     "robot.graham",
+            #     "/project/def-allen/SalishSea/forcing/rivers/river_turb/",
+            # ),
         ),
     )
     def test_fraser_turbidity_uploads(self, host, expected, prod_config):
@@ -199,7 +199,7 @@ class TestConfig:
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/rivers/"),
             ("optimum-hindcast", "/data/sallen/shared/SalishSeaCast/forcing/rivers/"),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/rivers/"),
-            ("robot.graham", "/project/def-allen/SalishSea/forcing/rivers/"),
+            # ("robot.graham", "/project/def-allen/SalishSea/forcing/rivers/"),
         ),
     )
     def test_river_runoff_uploads(self, host, expected, prod_config):
@@ -219,10 +219,10 @@ class TestConfig:
                 "/data/sallen/shared/SalishSeaCast/forcing/atmospheric/continental2.5/nemo_forcing/",
             ),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/continental2.5/NEMO-atmos/"),
-            (
-                "robot.graham",
-                "/project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
-            ),
+            # (
+            #     "robot.graham",
+            #     "/project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
+            # ),
         ),
     )
     def test_weather_uploads(self, host, expected, prod_config):
@@ -244,7 +244,7 @@ class TestConfig:
                 "/data/sallen/shared/SalishSeaCast/forcing/LiveOcean/",
             ),
             ("orcinus-nowcast-agrif", "/home/sallen/MEOPAR/LiveOcean/"),
-            ("robot.graham", "/project/def-allen/SalishSea/forcing/LiveOcean/"),
+            # ("robot.graham", "/project/def-allen/SalishSea/forcing/LiveOcean/"),
         ),
     )
     def test_live_ocean_uploads(self, host, expected, prod_config):


### PR DESCRIPTION
* Remove `robot.graham` from `enabled hosts` config to prevent forcing file uploads 
* Remove launch of `archive_tarball` worker at month-end to prevent uploads to `/nearline/`
* Disable corresponding tests to avoid nuisance test failures during downtime