### PR TITLE
Update httpx and fix caplog assertions in tests

### DIFF
--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -23,7 +23,7 @@ Bottleneck==1.4.2
 Brotli==1.1.0
 cached-property==1.5.2
 Cartopy==0.24.0
-certifi==2024.8.30
+certifi==2024.12.14
 cffi==1.17.1
 cfgrib==0.9.11.0
 cfgv==3.3.1
@@ -72,7 +72,7 @@ hatch==1.13.0
 hatchling==1.26.3
 hpack==4.0.0
 httpcore==1.0.7
-httpx==0.27.2
+httpx==0.28.1
 humanfriendly==10.0
 hyperframe==6.0.1
 hyperlink==21.0.0
@@ -142,7 +142,7 @@ PySide6==6.8.1
 PySocks==1.7.1
 pytest==8.3.4
 pytest-cov==6.0.0
-pytest-httpx==0.32.0
+pytest-httpx==0.35.0
 pytest-randomly==3.15.0
 pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -336,13 +336,13 @@ class TestGetUSGS_DayAvgDischarge:
         )
 
         numpy.testing.assert_almost_equal(day_avg_discharge, 43.0)
-        # httpx generates DEBUG & INFO level messages in records 0-2
-        assert caplog.records[3].levelname == "DEBUG"
+        # httpx generates an INFO level message in records 0
+        assert caplog.records[1].levelname == "DEBUG"
         expected = (
             f"average discharge for SkagitMountVernon on 2023-01-06 from "
             f"https://waterservices.usgs.gov/nwis/dv/: {day_avg_discharge:.6e} m^3/s"
         )
-        assert caplog.messages[3] == expected
+        assert caplog.messages[1] == expected
 
     def test_http_RequestError(self, config, httpx_mock, caplog):
         httpx_mock.add_exception(httpx.RequestError("error issuing request"))
@@ -353,10 +353,9 @@ class TestGetUSGS_DayAvgDischarge:
                 "SkagitMountVernon", "2023-01-06", config
             )
 
-        # httpx generates DEBUG & INFO level messages in records 0-1
-        assert caplog.records[2].levelname == "CRITICAL"
+        assert caplog.records[0].levelname == "CRITICAL"
         usgs_url = config["rivers"]["usgs url"]
-        assert caplog.messages[2].startswith(f"Error while requesting {usgs_url}")
+        assert caplog.messages[0].startswith(f"Error while requesting {usgs_url}")
 
     def test_HTTPStatusError(self, config, httpx_mock, caplog):
         httpx_mock.add_response(status_code=500)
@@ -367,10 +366,10 @@ class TestGetUSGS_DayAvgDischarge:
                 "SkagitMountVernon", "2023-01-06", config
             )
 
-        # httpx generates DEBUG & INFO level messages in records 0-2
-        assert caplog.records[3].levelname == "CRITICAL"
+        # httpx generates an INFO level message in records 0
+        assert caplog.records[1].levelname == "CRITICAL"
         usgs_url = config["rivers"]["usgs url"]
-        assert caplog.messages[3].startswith(
+        assert caplog.messages[1].startswith(
             f"Error response 500 while requesting {usgs_url}"
         )
 
@@ -383,9 +382,9 @@ class TestGetUSGS_DayAvgDischarge:
                 "SkagitMountVernon", "2023-01-06", config
             )
 
-        # httpx generates DEBUG & INFO level messages in records 0-2
-        assert caplog.records[3].levelname == "CRITICAL"
-        assert caplog.messages[3] == "SkagitMountVernon 2023-01-06 timeSeries is empty"
+        # httpx generates an INFO level message in records 0
+        assert caplog.records[1].levelname == "CRITICAL"
+        assert caplog.messages[1] == "SkagitMountVernon 2023-01-06 timeSeries is empty"
 
     @pytest.mark.parametrize(
         "values",
@@ -416,10 +415,10 @@ class TestGetUSGS_DayAvgDischarge:
                 "SkagitMountVernon", "2023-01-06", config
             )
 
-        # httpx generates DEBUG & INFO level messages in records 0-2
-        assert caplog.records[3].levelname == "CRITICAL"
+        # httpx generates an INFO level message in records 0
+        assert caplog.records[1].levelname == "CRITICAL"
         expected = "IndexError in SkagitMountVernon 2023-01-06 timeSeries JSON"
-        assert caplog.messages[3] == expected
+        assert caplog.messages[1] == expected
 
     @pytest.mark.parametrize(
         "value",
@@ -469,10 +468,10 @@ class TestGetUSGS_DayAvgDischarge:
                 "SkagitMountVernon", "2023-01-06", config
             )
 
-        # httpx generates DEBUG & INFO level messages in records 0-2
-        assert caplog.records[3].levelname == "CRITICAL"
+        # httpx generates an INFO level message in records 0
+        assert caplog.records[1].levelname == "CRITICAL"
         expected = "KeyError in SkagitMountVernon 2023-01-06 timeSeries JSON"
-        assert caplog.messages[3] == expected
+        assert caplog.messages[1] == expected
 
     def test_no_data(self, config, httpx_mock, caplog):
         httpx_mock.add_response(
@@ -504,12 +503,12 @@ class TestGetUSGS_DayAvgDischarge:
                 "SkagitMountVernon", "2023-01-06", config
             )
 
-        # httpx generates DEBUG & INFO level messages in records 0-2
-        assert caplog.records[3].levelname == "CRITICAL"
+        # httpx generates an INFO level message in records 0
+        assert caplog.records[1].levelname == "CRITICAL"
         expected = (
             "Got no-data value (-999999) in SkagitMountVernon 2023-01-06 timeSeries"
         )
-        assert caplog.messages[3] == expected
+        assert caplog.messages[1] == expected
 
 
 class TestStoreDayAvgDischarge:


### PR DESCRIPTION
Upgraded `httpx`, and `pytest-httpx` in `requirements.txt` to newer versions. Adjusted caplog index assertions in test cases to align with the updated logging behavior of `httpx`. This ensures compatibility and correct verification of log records across all affected tests.

This issue arose due to a change in the log output of `httpx=0.28.0`. It was found by the GitHub Actions pytest-with-coverage workflows when the tests were run with the updated version of `httpx` in response to an unrelated dependabot PR.