### PR TITLE
Update Codecov action to use 'files' instead of 'file'

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -56,6 +56,6 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Replaced the deprecated 'file' key with 'files' in the Codecov action configuration. This ensures compatibility with the latest Codecov action requirements and prevents potential upload issues.