### PR TITLE
Standardize Python exec commands to `python -m`

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -37,16 +37,16 @@ jobs:
       - name: Install editable-mode dependency packages
         shell: bash -l {0}
         run: |
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/43ravens/NEMO_Nowcast.git#egg=NEMO_Nowcast
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/UBC-MOAD/moad_tools#egg=moad_tools
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/UBC-MOAD/Reshapr#egg=Reshapr
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/NEMO-Cmd.git#egg=NEMO-Cmd
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/SalishSeaCmd.git#egg=SalishSeaCmd
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable "git+https://github.com/SalishSeaCast/tools#egg=SalishSeaTools&subdirectory=SalishSeaTools"
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/FVCOM-Cmd.git#egg=FVCOM-Cmd
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/43ravens/NEMO_Nowcast.git#egg=NEMO_Nowcast
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/UBC-MOAD/moad_tools#egg=moad_tools
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/UBC-MOAD/Reshapr#egg=Reshapr
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/NEMO-Cmd.git#egg=NEMO-Cmd
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/SalishSeaCmd.git#egg=SalishSeaCmd
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable "git+https://github.com/SalishSeaCast/tools#egg=SalishSeaTools&subdirectory=SalishSeaTools"
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://github.com/SalishSeaCast/FVCOM-Cmd.git#egg=FVCOM-Cmd
           # OPPTools is a private GitLab repo, so an access token is required
-          python3 -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://oauth2:${{ secrets.GITLAB_ACCESS_TOKEN }}@gitlab.com/mdunphy/OPPTools.git@6c784a4dc44dd9030aafe9a8519e5ae0b6cc3183#egg=OPPTools
-          python3 -m pip install --editable $GITHUB_WORKSPACE
+          python -m pip install --src $GITHUB_WORKSPACE/../vcs_pkgs/ --editable git+https://oauth2:${{ secrets.GITLAB_ACCESS_TOKEN }}@gitlab.com/mdunphy/OPPTools.git@6c784a4dc44dd9030aafe9a8519e5ae0b6cc3183#egg=OPPTools
+          python -m pip install --editable $GITHUB_WORKSPACE
 
       - name: pytest package with coverage
         shell: bash -l {0}

--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -4,7 +4,7 @@
 checklist file: $(NOWCAST.ENV.NOWCAST_LOGS)/nowcast_checklist.yaml
 
 # Python interpreter in environment with all dependencies installed
-python: $(NOWCAST.ENV.NOWCAST_ENV)/bin/python3
+python: $(NOWCAST.ENV.NOWCAST_ENV)/bin/python
 
 # Filesystem group name to use for ownership of newly created files
 file group: sallen
@@ -627,7 +627,7 @@ run:
       # Python interpreter on compute host in an environment with all
       # dependencies installed. Used to, for example, launch run_NEMO and
       # watch_NEMO workers.
-      python: /nemoShare/MEOPAR/nowcast-sys/nowcast-env/bin/python3
+      python: /nemoShare/MEOPAR/nowcast-sys/nowcast-env/bin/python
       # Location on the compute host of the nowcast system config file
       config file: /nemoShare/MEOPAR/nowcast-sys/SalishSeaNowcast/config/nowcast.yaml
       # Directory on compute host where files (e.g. namelist.time) and symlinks

--- a/docs/deployment/optimum.rst
+++ b/docs/deployment/optimum.rst
@@ -217,15 +217,15 @@ Load the ``Miniconda/3`` module and create a Conda environment:
     $ conda create -n salishseacast -c conda-forge python=3 pip arrow \
       attrs cliff f90nml gitpython pyyaml
     $ source activate salishseacast
-    (salishseacast)$ python3 -m pip install python-hglib
+    (salishseacast)$ python -m pip install python-hglib
 
 Install the SalishSeaCast NEMO-Cmd and SalishSeaCmd packages from their repo clones:
 
 .. code-block:: bash
 
     (salishseacast)$ cd $PROJECT/SalishSeaCast/hindcast-sys/
-    (salishseacast)$ python3 -m pip install --editable NEMO-Cmd/
-    (salishseacast)$ python3 -m pip install --editable SalishSeaCmd/
+    (salishseacast)$ python -m pip install --editable NEMO-Cmd/
+    (salishseacast)$ python -m pip install --editable SalishSeaCmd/
 
 
 Populate Run Preparation Directory

--- a/docs/deployment/skookum.rst
+++ b/docs/deployment/skookum.rst
@@ -109,7 +109,7 @@ For the `salishsea-site web app`_ that is mounted at https://salishsea.eos.ubc.c
         --prefix /SalishSeaCast/salishsea-site-env \
         -f salishsea-site/envs/environment-prod.yaml
     $ mamba activate /SalishSeaCast/salishsea-site-env
-    (/SalishSeaCast/salishsea-site-env) $ python3 -m pip install --editable salishsea-site/
+    (/SalishSeaCast/salishsea-site-env) $ python -m pip install --editable salishsea-site/
 
 
 Environment Variables

--- a/docs/figures/fig_dev_env.rst
+++ b/docs/figures/fig_dev_env.rst
@@ -70,14 +70,14 @@ you can create and activate a figures development environment with these command
     $ cd SalishSeaNowcast
     $ conda env create -f envs/environment-fig-dev.yaml
     $ conda activate nowcast-fig-dev
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../NEMO_Nowcast
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../moad_tools
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../Reshapr
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../tools/SalishSeaTools
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../NEMO-Cmd
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../SalishSeaCmd
-    (nowcast-fig-dev)$ python3 -m pip install --editable ../salishsea-site/
-    (nowcast-fig-dev)$ python3 -m pip install --editable .
+    (nowcast-fig-dev)$ python -m pip install --editable ../NEMO_Nowcast
+    (nowcast-fig-dev)$ python -m pip install --editable ../moad_tools
+    (nowcast-fig-dev)$ python -m pip install --editable ../Reshapr
+    (nowcast-fig-dev)$ python -m pip install --editable ../tools/SalishSeaTools
+    (nowcast-fig-dev)$ python -m pip install --editable ../NEMO-Cmd
+    (nowcast-fig-dev)$ python -m pip install --editable ../SalishSeaCmd
+    (nowcast-fig-dev)$ python -m pip install --editable ../salishsea-site/
+    (nowcast-fig-dev)$ python -m pip install --editable .
 
 The ``--editable`` option in the :command:`pip install` command above installs the packages from the cloned repos via symlinks so that the installed packages will be automatically updated as the repos evolve.
 

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -163,18 +163,18 @@ the commands below install the packages into your ``salishsea-nowcast`` developm
     $ cd SalishSeaNowcast
     $ conda env create -f envs/environment-dev.yaml
     $ conda activate salishsea-nowcast
-    (salishsea-nowcast)$ python3 -m pip install --editable ../NEMO_Nowcast
-    (salishsea-nowcast)$ python3 -m pip install --editable ../moad_tools
-    (salishsea-nowcast)$ python3 -m pip install --editable ../Reshapr
-    (salishsea-nowcast)$ python3 -m pip install --editable ../tools/SalishSeaTools
+    (salishsea-nowcast)$ python -m pip install --editable ../NEMO_Nowcast
+    (salishsea-nowcast)$ python -m pip install --editable ../moad_tools
+    (salishsea-nowcast)$ python -m pip install --editable ../Reshapr
+    (salishsea-nowcast)$ python -m pip install --editable ../tools/SalishSeaTools
     (salishsea-nowcast)$ cd ../OPPTools
     (salishsea-nowcast)$ git switch SalishSeaCast-prod
     (salishsea-nowcast)$ cd ../SalishSeaNowcast
-    (salishsea-nowcast)$ python3 -m pip install --editable OPPTools
-    (salishsea-nowcast)$ python3 -m pip install --editable ../NEMO-Cmd
-    (salishsea-nowcast)$ python3 -m pip install --editable ../SalishSeaCmd
-    (salishsea-nowcast)$ python3 -m pip install --editable ../FVCOM-Cmd
-    (salishsea-nowcast)$ python3 -m pip install --editable .
+    (salishsea-nowcast)$ python -m pip install --editable OPPTools
+    (salishsea-nowcast)$ python -m pip install --editable ../NEMO-Cmd
+    (salishsea-nowcast)$ python -m pip install --editable ../SalishSeaCmd
+    (salishsea-nowcast)$ python -m pip install --editable ../FVCOM-Cmd
+    (salishsea-nowcast)$ python -m pip install --editable .
 
 The ``--editable`` option in the :command:`pip install` command above installs the packages from the cloned repos via symlinks so that the installed packages will be automatically updated as the repos evolve.
 

--- a/docs/worker_failures.rst
+++ b/docs/worker_failures.rst
@@ -87,7 +87,7 @@ then run the worker as follows:
 
    .. code-block:: bash
 
-       (/SalishSeaCast/nowcast-env)skookum$ python3 -m nowcast.workers.download_weather $NOWCAST_YAML 12 2.5km --debug
+       (/SalishSeaCast/nowcast-env)skookum$ python -m nowcast.workers.download_weather $NOWCAST_YAML 12 2.5km --debug
 
    The command above downloads the 12 forecast.
    The ``--debug`` flag causes the logging output of the worker to be displayed

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -6,15 +6,15 @@
 #
 #    $ conda env create -f SalishSeaNowcast/envs/environment-dev.yaml
 #    $ conda activate salishsea-nowcast
-#    $ python3 -m pip install --editable NEMO_Nowcast/
-#    $ python3 -m pip install --editable moad_tools/
-#    $ python3 -m pip install --editable tools/SalishSeaTools/
-#    $ python3 -m pip install --editable Reshapr/
-#    $ python3 -m pip install --editable OPPTools/
-#    $ python3 -m pip install --editable NEMO-Cmd/
-#    $ python3 -m pip install --editable SalishSeaCmd/
-#    $ python3 -m pip install --editable FVCOM-Cmd/
-#    $ python3 -m pip install --editable SalishSeaNowcast/
+#    $ python -m pip install --editable NEMO_Nowcast/
+#    $ python -m pip install --editable moad_tools/
+#    $ python -m pip install --editable tools/SalishSeaTools/
+#    $ python -m pip install --editable Reshapr/
+#    $ python -m pip install --editable OPPTools/
+#    $ python -m pip install --editable NEMO-Cmd/
+#    $ python -m pip install --editable SalishSeaCmd/
+#    $ python -m pip install --editable FVCOM-Cmd/
+#    $ python -m pip install --editable SalishSeaNowcast/
 
 name: salishsea-nowcast
 

--- a/envs/environment-fig-dev.yaml
+++ b/envs/environment-fig-dev.yaml
@@ -5,14 +5,14 @@
 #
 #    $ conda env create -f SalishSeaNowcast/envs/environment-fig-dev.yaml
 #    $ conda activate nowcast-fig-dev
-#    $ python3 -m pip install --editable NEMO_Nowcast/
-#    $ python3 -m pip install --editable moad_tools/
-#    $ python3 -m pip install --editable Reshapr/
-#    $ python3 -m pip install --editable tools/SalishSeaTools/
-#    $ python3 -m pip install --editable NEMO-Cmd/
-#    $ python3 -m pip install --editable SalishSeaCmd/
-#    $ python3 -m pip install --editable SalishSeaNowcast/
-#    $ python3 -m pip install --editable salishsea-site/
+#    $ python -m pip install --editable NEMO_Nowcast/
+#    $ python -m pip install --editable moad_tools/
+#    $ python -m pip install --editable Reshapr/
+#    $ python -m pip install --editable tools/SalishSeaTools/
+#    $ python -m pip install --editable NEMO-Cmd/
+#    $ python -m pip install --editable SalishSeaCmd/
+#    $ python -m pip install --editable SalishSeaNowcast/
+#    $ python -m pip install --editable salishsea-site/
 
 name: nowcast-fig-dev
 

--- a/envs/environment-prod.yaml
+++ b/envs/environment-prod.yaml
@@ -6,15 +6,15 @@
 #
 #    $ conda env create -f SalishSeaNowcast/envs/environment-prod.yaml
 #    $ conda activate nowcast-env
-#    $ python3 -m pip install --editable NEMO_Nowcast/
-#    $ python3 -m pip install --editable moad_tools/
-#    $ python3 -m pip install --editable tools/SalishSeaTools/
-#    $ python3 -m pip install --editable Reshapr/
-#    $ python3 -m pip install --editable OPPTools/
-#    $ python3 -m pip install --editable NEMO-Cmd/
-#    $ python3 -m pip install --editable SalishSeaCmd/
-#    $ python3 -m pip install --editable FVCOM-Cmd/
-#    $ python3 -m pip install --editable SalishSeaNowcast/
+#    $ python -m pip install --editable NEMO_Nowcast/
+#    $ python -m pip install --editable moad_tools/
+#    $ python -m pip install --editable tools/SalishSeaTools/
+#    $ python -m pip install --editable Reshapr/
+#    $ python -m pip install --editable OPPTools/
+#    $ python -m pip install --editable NEMO-Cmd/
+#    $ python -m pip install --editable SalishSeaCmd/
+#    $ python -m pip install --editable FVCOM-Cmd/
+#    $ python -m pip install --editable SalishSeaNowcast/
 
 name: nowcast-env
 

--- a/envs/requirements-sarracenia.txt
+++ b/envs/requirements-sarracenia.txt
@@ -5,7 +5,7 @@
 # to create an isolated production environment.
 #
 # Create/update this file with:
-#   (sarracenia-env)$ python3 -m pip list --format=freeze >> envs/requirements-sarracenia.txt
+#   (sarracenia-env)$ python -m pip list --format=freeze >> envs/requirements-sarracenia.txt
 
 amqp==5.1.0
 appdirs==1.4.4

--- a/notebooks/figures/fvcom/research/make_readme.py
+++ b/notebooks/figures/fvcom/research/make_readme.py
@@ -19,7 +19,7 @@ rename a notebook,
 or change the description of a notebook in its first Markdown cell,
 please generate a updated `README.md` file with:
 
-    python3 -m make_readme
+    python -m make_readme
 
 and commit and push the updated `README.md` to GitHub.
 """

--- a/notebooks/make_readme.py
+++ b/notebooks/make_readme.py
@@ -19,7 +19,7 @@ rename a notebook,
 or change the description of a notebook in its first Markdown cell,
 please generate a updated `README.md` file with:
 
-    python3 -m make_readme
+    python -m make_readme
 
 and commit and push the updated `README.md` to GitHub.
 """

--- a/nowcast/daily_river_flows.py
+++ b/nowcast/daily_river_flows.py
@@ -530,7 +530,7 @@ def _calc_runoff_dataset(obs_date, runoff_array, config):
             "rivers_watersheds_proportions": "salishsea_tools.river_202108",
             "history": (
                 f"[{arrow.now('local').format('ddd YYYY-MM-DD HH:mm:ss ZZ')}] "
-                f"python3 -m nowcast.workers.make_runoff_file $NOWCAST_YAML "
+                f"python -m nowcast.workers.make_runoff_file $NOWCAST_YAML "
                 f"--run-date {obs_date.format('YYYY-MM-DD')}"
             ),
         },

--- a/nowcast/workers/make_v202111_runoff_file.py
+++ b/nowcast/workers/make_v202111_runoff_file.py
@@ -613,7 +613,7 @@ def _calc_runoff_dataset(obs_date, runoff_array, config):
             ],
             "history": (
                 f"[{arrow.now('local').format('ddd YYYY-MM-DD HH:mm:ss ZZ')}] "
-                f"python3 -m nowcast.workers.make_v202111_runoff_file $NOWCAST_YAML "
+                f"python -m nowcast.workers.make_v202111_runoff_file $NOWCAST_YAML "
                 f"--run-date {obs_date_yyyymmdd}"
             ),
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,16 +92,16 @@ dependencies = [
     "utm",
     "watchdog",
     "xarray == 2025.1.1",
-    # 'NEMO_Nowcast',  # use python3 -m pip install --editable NEMO_Nowcast/
-    # 'moad_tools',  # use python3 -m pip install --editable moad_tools
-    # 'Reshapr',  # use python3 -m pip install --editable Reshapr
-    # 'SalishSeaTools',  # use python3 -m pip install --editable tools/SalishSeaTools/
-    # 'Reshapr',  # use python3 -m pip install --editable Reshapr/
-    # 'OPPTools',  # use python3 -m pip install --editable OPPTools/
-    # 'NEMO-Cmd',  # use python3 -m pip install --editable NEMO-Cmd/
-    # 'SalishSeaCmd',  # use python3 -m pip install --editable SalishSeaCmd/
-    # 'FVCOM-Cmd',  # use python3 -m pip install --editable FVCOM-Cmd/
-    # 'SalishSeaNowcast',  # use python3 -m pip install -e SalishSeaNowcast/
+    # 'NEMO_Nowcast',  # use python -m pip install --editable NEMO_Nowcast/
+    # 'moad_tools',  # use python -m pip install --editable moad_tools
+    # 'Reshapr',  # use python -m pip install --editable Reshapr
+    # 'SalishSeaTools',  # use python -m pip install --editable tools/SalishSeaTools/
+    # 'Reshapr',  # use python -m pip install --editable Reshapr/
+    # 'OPPTools',  # use python -m pip install --editable OPPTools/
+    # 'NEMO-Cmd',  # use python -m pip install --editable NEMO-Cmd/
+    # 'SalishSeaCmd',  # use python -m pip install --editable SalishSeaCmd/
+    # 'FVCOM-Cmd',  # use python -m pip install --editable FVCOM-Cmd/
+    # 'SalishSeaNowcast',  # use python -m pip install -e SalishSeaNowcast/
 ]
 
 [project.urls]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ class TestConfig:
 
     def test_python(self, prod_config, tmpdir):
         # Config.load() transforms NOWCAST.ENV part of envvars
-        assert prod_config["python"] == f"{tmpdir}/nowcast-env/bin/python3"
+        assert prod_config["python"] == f"{tmpdir}/nowcast-env/bin/python"
 
 
 class TestLoggingPublisher:

--- a/tests/test_daily_river_flows.py
+++ b/tests/test_daily_river_flows.py
@@ -1496,7 +1496,7 @@ class TestCalcRunoffDataset:
         )
         assert runoff_ds.attrs["history"] == (
             f"[Thu {obs_date.format('YYYY-MM-DD')} 14:51:43 -07:00] "
-            f"python3 -m nowcast.workers.make_runoff_file $NOWCAST_YAML "
+            f"python -m nowcast.workers.make_runoff_file $NOWCAST_YAML "
             f"--run-date {obs_date.format('YYYY-MM-DD')}"
         )
 

--- a/tests/workers/test_make_v202111_runoff_file.py
+++ b/tests/workers/test_make_v202111_runoff_file.py
@@ -1920,7 +1920,7 @@ class TestCalcRunoffDataset:
         )
         assert runoff_ds.attrs["history"] == (
             f"[Thu {obs_date.format('YYYY-MM-DD')} 14:51:43 -07:00] "
-            f"python3 -m nowcast.workers.make_v202111_runoff_file $NOWCAST_YAML "
+            f"python -m nowcast.workers.make_v202111_runoff_file $NOWCAST_YAML "
             f"--run-date {obs_date.format('YYYY-MM-DD')}"
         )
 


### PR DESCRIPTION
Replaced `python3 -m` usage with `python -m` across the codebase and documentation for consistency. This ensures alignment with modern Python practices.