### PR TITLE
Switch test logging from mock logger to caplog.

### DIFF
--- a/nowcast/workers/watch_NEMO.py
+++ b/nowcast/workers/watch_NEMO.py
@@ -12,6 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """SalishSeaCast worker that monitors and reports on the progress of a run on the cloud
 computing facility or salish.
 """
@@ -56,14 +60,16 @@ def main():
 
 
 def success(parsed_args):
-    logger.info("{0.run_type} NEMO run on {0.host_name} completed".format(parsed_args))
-    msg_type = "success {.run_type}".format(parsed_args)
+    logger.info(f"{parsed_args.run_type} NEMO run on {parsed_args.host_name} completed")
+    msg_type = f"success {parsed_args.run_type}"
     return msg_type
 
 
 def failure(parsed_args):
-    logger.critical("{0.run_type} NEMO run on {0.host_name} failed".format(parsed_args))
-    msg_type = "failure {.run_type}".format(parsed_args)
+    logger.critical(
+        f"{parsed_args.run_type} NEMO run on {parsed_args.host_name} failed"
+    )
+    msg_type = f"failure {parsed_args.run_type}"
     return msg_type
 
 
@@ -254,7 +260,7 @@ def _confirm_run_success(
                         run_succeeded = False
                         logger.critical(
                             f"{host_name} {run_type}/{dmy} run failed; "
-                            f'NaN in: {results_dir/"solver.stat"}'
+                            f'NaN in: {results_dir/"tracer.stat"}'
                         )
                         break
         except FileNotFoundError:

--- a/nowcast/workers/watch_NEMO_hindcast.py
+++ b/nowcast/workers/watch_NEMO_hindcast.py
@@ -486,7 +486,7 @@ class _SqueueHindcastJob:
             cmd, f"{self.run_id} on {self.host_name}: cancelled {self.job_id}"
         )
         if len(error_lines) != 1:
-            # More than 1 "E R R O R" line mean the run failed irrevocably
+            # More than 1 "E R R O R" line means the run failed irrevocably
             return False
         # Exactly 1 "E R R O R" line means the run is "stuck" and it can be re-queued
         self._handle_stuck_job()

--- a/release_mgmt/tag_release.py
+++ b/release_mgmt/tag_release.py
@@ -131,9 +131,9 @@ def _tag_repo(repo, tag):
                 message=f"Tag production release {tag}.",
                 user=f"{COMMIT_AUTHOR} for {username}",
             )
-        logger.success(f"added {tag} to repo: {repo}")
+        logger.info(f"added {tag} to repo: {repo}")
         hg.push()
-        logger.success(f"pushed {tag} tag to Bitbucket from repo: {repo}")
+        logger.info(f"pushed {tag} tag to Bitbucket from repo: {repo}")
 
 
 if __name__ == "__main__":

--- a/tests/release_mgmt/test_tag_release.py
+++ b/tests/release_mgmt/test_tag_release.py
@@ -17,7 +17,8 @@
 
 
 """Unit tests for SalishSeaCast tag_release script."""
-from unittest.mock import Mock, call, patch
+import logging
+from unittest.mock import Mock, patch
 
 import hglib
 import pytest
@@ -25,47 +26,62 @@ import pytest
 from release_mgmt import tag_release
 
 
-@patch("release_mgmt.tag_release.logger", autospec=True)
 @patch("release_mgmt.tag_release.Path.exists", return_value=True, autospec=True)
 @patch("release_mgmt.tag_release.hglib.open", autospec=True)
 class TestTagRepo:
     """Unit tests for _rag_repo() function."""
 
-    def test_repo_not_exists(self, m_hg_open, m_exists, m_logger):
+    def test_repo_not_exists(self, m_hg_open, m_exists, caplog):
         m_exists.return_value = False
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(SystemExit):
             tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
-        m_logger.error.assert_called_once_with("repo does not exist: NEMO-3.6-code")
 
-    def test_no_repo_root(self, m_hg_open, m_exists, m_logger):
+        assert caplog.records[1].levelname == "ERROR"
+        expected = "repo does not exist: NEMO-3.6-code"
+        assert caplog.records[1].message == expected
+
+    def test_no_repo_root(self, m_hg_open, m_exists, caplog):
         m_hg_open.side_effect = hglib.error.ServerError
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(SystemExit):
             tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
-        m_logger.error.assert_called_once_with(
-            "unable to find Mercurial repo root in: NEMO-3.6-code"
-        )
 
-    def test_uncommitted_changes(self, m_hg_open, m_exists, m_logger):
+        assert caplog.records[1].levelname == "ERROR"
+        expected = "unable to find Mercurial repo root in: NEMO-3.6-code"
+        assert caplog.records[1].message == expected
+
+    def test_uncommitted_changes(self, m_hg_open, m_exists, caplog):
         m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_open().__enter__.status.return_value = None
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(SystemExit):
             tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
-        m_logger.error.assert_called_once_with(
-            "uncommitted changes in repo: NEMO-3.6-code"
-        )
 
-    def test_incoming_changes(self, m_hg_open, m_exists, m_logger):
+        assert caplog.records[1].levelname == "ERROR"
+        expected = "uncommitted changes in repo: NEMO-3.6-code"
+        assert caplog.records[1].message == expected
+
+    def test_incoming_changes(self, m_hg_open, m_exists, caplog):
         m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_open().__enter__().status.return_value = None
         m_hg_open().__enter__().incoming.return_value = ["changesets"]
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(SystemExit):
             tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
-        m_logger.warning.assert_called_once_with(
+
+        assert caplog.records[1].levelname == "WARNING"
+        expected = (
             "found incoming changes from Bitbucket that you need to deal "
             "with in repo: NEMO-3.6-code"
         )
+        assert caplog.records[1].message == expected
 
-    def test_hg_tag(self, m_hg_open, m_exists, m_logger):
+    def test_hg_tag(self, m_hg_open, m_exists, caplog):
         m_hg_client = m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_client().status.return_value = None
         m_hg_client().incoming.return_value = []
@@ -73,7 +89,10 @@ class TestTagRepo:
         m_hg_client().config.return_value = [
             (b"ui", b"username", b"Tom Dickson <tom@example.com>")
         ]
+        caplog.set_level(logging.DEBUG)
+
         tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
+
         expected = "PROD-hindcast-201806-v2-2017".encode()
         assert m_hg_client().tag.call_args_list[0][0][0] == expected
         expected = {
@@ -81,11 +100,11 @@ class TestTagRepo:
             "user": "SalishSeaNowcast.release_mgmt.tag_release for Tom Dickson <tom@example.com>",
         }
         assert m_hg_client().tag.call_args_list[0][1] == expected
-        assert m_logger.success.call_args_list[0] == call(
-            "added PROD-hindcast-201806-v2-2017 to repo: NEMO-3.6-code"
-        )
+        assert caplog.records[1].levelname == "INFO"
+        expected = "added PROD-hindcast-201806-v2-2017 to repo: NEMO-3.6-code"
+        assert caplog.records[1].message == expected
 
-    def test_duplicate_tag(self, m_hg_open, m_exists, m_logger):
+    def test_duplicate_tag(self, m_hg_open, m_exists, caplog):
         m_hg_client = m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_client().status.return_value = None
         m_hg_client().incoming.return_value = []
@@ -93,13 +112,18 @@ class TestTagRepo:
             (b"tip", 9, b"ff71fb7feaa6", False),
             (b"PROD-hindcast-201806-v2-2017", 7, b"3541bdb39959", False),
         ]
+        caplog.set_level(logging.DEBUG)
+
         tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
-        m_logger.warning.assert_called_once_with(
+
+        assert caplog.records[1].levelname == "WARNING"
+        expected = (
             "tag 'PROD-hindcast-201806-v2-2017' already exists in repo: NEMO-3.6-code"
         )
+        assert caplog.records[1].message == expected
         assert not m_hg_client.push.called
 
-    def test_tip_is_tagging_commit(self, m_hg_open, m_exists, m_logger):
+    def test_tip_is_tagging_commit(self, m_hg_open, m_exists, caplog):
         m_hg_client = m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_client().status.return_value = None
         m_hg_client().incoming.return_value = []
@@ -114,7 +138,10 @@ class TestTagRepo:
         m_hg_client().tip().desc = (
             b"Tag production release PROD-hindcast-201806-v2-2017."
         )
+        caplog.set_level(logging.DEBUG)
+
         tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v3-2017")
+
         expected = "PROD-hindcast-201806-v3-2017".encode()
         assert m_hg_client().tag.call_args_list[0][0][0] == expected
         expected = {
@@ -123,11 +150,11 @@ class TestTagRepo:
             "user": "SalishSeaNowcast.release_mgmt.tag_release for Tom Dickson <tom@example.com>",
         }
         assert m_hg_client().tag.call_args_list[0][1] == expected
-        assert m_logger.success.call_args_list[0] == call(
-            "added PROD-hindcast-201806-v3-2017 to repo: NEMO-3.6-code"
-        )
+        assert caplog.records[1].levelname == "INFO"
+        expected = "added PROD-hindcast-201806-v3-2017 to repo: NEMO-3.6-code"
+        assert caplog.records[1].message == expected
 
-    def test_hg_tag_error(self, m_hg_open, m_exists, m_logger):
+    def test_hg_tag_error(self, m_hg_open, m_exists, caplog):
         m_hg_client = m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_client().status.return_value = None
         m_hg_client().incoming.return_value = []
@@ -138,11 +165,13 @@ class TestTagRepo:
         m_hg_client().tag.side_effect = hglib.error.CommandError(
             ("args",), "ret", "out", b"err"
         )
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(hglib.error.CommandError):
             tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
         assert not m_hg_client.push.called
 
-    def test_hg_push(self, m_hg_open, m_exists, m_logger):
+    def test_hg_push(self, m_hg_open, m_exists, caplog):
         m_hg_client = m_hg_open().__enter__ = Mock(name="hg_client")
         m_hg_client().status.return_value = None
         m_hg_client().incoming.return_value = []
@@ -150,9 +179,11 @@ class TestTagRepo:
         m_hg_client().config.return_value = [
             (b"ui", b"username", b"Tom Dickson <tom@example.com>")
         ]
+        caplog.set_level(logging.DEBUG)
+
         tag_release._tag_repo("NEMO-3.6-code", "PROD-hindcast-201806-v2-2017")
+
         m_hg_client().push.assert_called_once_with()
-        assert m_logger.success.call_args_list[1] == call(
-            "pushed PROD-hindcast-201806-v2-2017 tag to Bitbucket from repo: "
-            "NEMO-3.6-code"
-        )
+        assert caplog.records[2].levelname == "INFO"
+        expected = "pushed PROD-hindcast-201806-v2-2017 tag to Bitbucket from repo: NEMO-3.6-code"
+        assert caplog.records[2].message == expected

--- a/tests/workers/test_make_runoff_file.py
+++ b/tests/workers/test_make_runoff_file.py
@@ -1986,7 +1986,7 @@ class TestWriteNetcdf:
 
         runoff_ds = xarray.Dataset()
         obs_date = arrow.get("2023-05-30")
-        caplog.set_level("DEBUG")
+        caplog.set_level(logging.DEBUG)
 
         nc_file_path = make_runoff_file._write_netcdf(
             runoff_ds, bathy_version, obs_date, config

--- a/tests/workers/test_make_turbidity_file.py
+++ b/tests/workers/test_make_turbidity_file.py
@@ -17,8 +17,8 @@
 
 
 """Unit tests for SalishSeaCast make_turbidity_file worker."""
+import logging
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import arrow
 import nemo_nowcast
@@ -57,23 +57,31 @@ class TestMain:
         assert worker.cli.parser._actions[3].help
 
 
-@patch("nowcast.workers.make_turbidity_file.logger", autospec=True)
 class TestSuccess:
     """Unit test for success() function."""
 
-    def test_success(self, m_logger):
+    def test_success(self, caplog):
         parsed_args = SimpleNamespace(run_date=arrow.get("2017-07-08"))
+        caplog.set_level(logging.DEBUG)
+
         msg_type = make_turbidity_file.success(parsed_args)
-        assert m_logger.info.called
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = "2017-07-08 Fraser River turbidity file creation complete"
+        assert caplog.records[0].message == expected
         assert msg_type == "success"
 
 
-@patch("nowcast.workers.make_turbidity_file.logger", autospec=True)
 class TestFailure:
     """Unit test for failure() function."""
 
-    def test_failure(self, m_logger):
+    def test_failure(self, caplog):
         parsed_args = SimpleNamespace(run_date=arrow.get("2017-07-08"))
+        caplog.set_level(logging.DEBUG)
+
         msg_type = make_turbidity_file.failure(parsed_args)
-        assert m_logger.critical.called
-        assert msg_type == f"failure"
+
+        assert caplog.records[0].levelname == "CRITICAL"
+        expected = "2017-07-08 Fraser River turbidity file creation failed"
+        assert caplog.records[0].message == expected
+        assert msg_type == "failure"

--- a/tests/workers/test_make_ww3_current_file.py
+++ b/tests/workers/test_make_ww3_current_file.py
@@ -403,7 +403,7 @@ class TestCalcNowcastDatasets:
         run_date = arrow.get("2023-03-16")
         nemo_dir = Path("/nemoShare/MEOPAR/SalishSea/")
         nemo_file_tmpl = "SalishSea_1h_{s_yyyymmdd}_{e_yyyymmdd}_grid_{grid}.nc"
-        caplog.set_level("DEBUG")
+        caplog.set_level(logging.DEBUG)
 
         datasets = make_ww3_current_file._calc_nowcast_datasets(
             run_date, nemo_dir, nemo_file_tmpl
@@ -437,7 +437,7 @@ class TestCalcForecastDatasets:
         run_date = arrow.get("2023-03-16")
         nemo_dir = Path("/nemoShare/MEOPAR/SalishSea/")
         nemo_file_tmpl = "SalishSea_1h_{s_yyyymmdd}_{e_yyyymmdd}_grid_{grid}.nc"
-        caplog.set_level("DEBUG")
+        caplog.set_level(logging.DEBUG)
 
         datasets = make_ww3_current_file._calc_forecast_datasets(
             run_date, nemo_dir, nemo_file_tmpl

--- a/tests/workers/test_make_ww3_current_file.py
+++ b/tests/workers/test_make_ww3_current_file.py
@@ -19,6 +19,7 @@
 """Unit tests for Salish Sea WaveWatch3 forecast worker make_ww3_current_file
 worker.
 """
+import logging
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -158,34 +159,42 @@ class TestConfig:
 
 
 @pytest.mark.parametrize("run_type", ["forecast2", "forecast"])
-@patch("nowcast.workers.make_ww3_current_file.logger", autospec=True)
 class TestSuccess:
     """Unit tests for success() function."""
 
-    def test_success(self, m_logger, run_type):
+    def test_success(self, run_type, caplog):
         parsed_args = SimpleNamespace(
             host_name="arbutus.cloud",
             run_type=run_type,
             run_date=arrow.get("2017-04-07"),
         )
+        caplog.set_level(logging.DEBUG)
+
         msg_type = make_ww3_current_file.success(parsed_args)
-        assert m_logger.info.called
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = f"wwatch3 currents forcing file created on arbutus.cloud for 2017-04-07 {run_type} run"
+        assert caplog.messages[0] == expected
         assert msg_type == f"success {run_type}"
 
 
 @pytest.mark.parametrize("run_type", ["forecast2", "forecast"])
-@patch("nowcast.workers.make_ww3_current_file.logger", autospec=True)
 class TestFailure:
     """Unit tests for failure() function."""
 
-    def test_failure(self, m_logger, run_type):
+    def test_failure(self, run_type, caplog):
         parsed_args = SimpleNamespace(
             host_name="arbutus.cloud",
             run_type=run_type,
             run_date=arrow.get("2017-04-07"),
         )
+        caplog.set_level(logging.DEBUG)
+
         msg_type = make_ww3_current_file.failure(parsed_args)
-        assert m_logger.critical.called
+
+        assert caplog.records[0].levelname == "CRITICAL"
+        expected = f"wwatch3 currents forcing file creation failed on arbutus.cloud for 2017-04-07 {run_type} run"
+        assert caplog.messages[0] == expected
         assert msg_type == f"failure {run_type}"
 
 
@@ -194,7 +203,6 @@ class TestFailure:
 @patch("nowcast.workers.make_ww3_current_file.viz_tools.rotate_vel", autospec=True)
 @patch("nowcast.workers.make_ww3_current_file.xarray.open_mfdataset", autospec=True)
 @patch("nowcast.workers.make_ww3_current_file.xarray.open_dataset", autospec=True)
-@patch("nowcast.workers.make_ww3_current_file.logger", autospec=True)
 class TestMakeWW3CurrentFile:
     """Unit tests for make_ww3_current_file() function."""
 
@@ -213,7 +221,6 @@ class TestMakeWW3CurrentFile:
         m_calc_fcst2_datasets,
         m_calc_fcst_datasets,
         m_calc_ncst_datasets,
-        m_logger,
         m_open_dataset,
         m_open_mfdataset,
         m_rotate_vel,
@@ -221,6 +228,7 @@ class TestMakeWW3CurrentFile:
         m_create_dataset,
         run_type,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name="arbutus.cloud",
@@ -229,7 +237,10 @@ class TestMakeWW3CurrentFile:
         )
         m_unstagger.return_value = (MagicMock(), MagicMock())
         m_rotate_vel.return_value = (MagicMock(), MagicMock())
+        caplog.set_level(logging.DEBUG)
+
         checklist = make_ww3_current_file.make_ww3_current_file(parsed_args, config)
+
         assert checklist == {
             run_type: "/nemoShare/MEOPAR/nowcast-sys/wwatch3-runs/current/SoG_current_20190805.nc",
             "run date": "2019-08-05",
@@ -279,7 +290,6 @@ class TestMakeWW3CurrentFile:
         m_calc_fcst2_datasets,
         m_calc_fcst_datasets,
         m_calc_ncst_datasets,
-        m_logger,
         m_open_dataset,
         m_open_mfdataset,
         m_rotate_vel,
@@ -288,6 +298,7 @@ class TestMakeWW3CurrentFile:
         run_type,
         expected_call,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name="arbutus.cloud",
@@ -296,7 +307,10 @@ class TestMakeWW3CurrentFile:
         )
         m_unstagger.return_value = (MagicMock(), MagicMock())
         m_rotate_vel.return_value = (MagicMock(), MagicMock())
+        caplog.set_level(logging.DEBUG)
+
         checklist = make_ww3_current_file.make_ww3_current_file(parsed_args, config)
+
         func_mocks = {
             "forecast2": m_calc_fcst2_datasets,
             "forecast": m_calc_fcst_datasets,
@@ -312,7 +326,6 @@ class TestMakeWW3CurrentFile:
         self,
         m_calc_fcst2_datasets,
         m_calc_fcst_datasets,
-        m_logger,
         m_open_dataset,
         m_open_mfdataset,
         m_rotate_vel,
@@ -320,6 +333,7 @@ class TestMakeWW3CurrentFile:
         m_create_dataset,
         run_type,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name="arbutus.cloud",
@@ -328,7 +342,10 @@ class TestMakeWW3CurrentFile:
         )
         m_unstagger.return_value = (MagicMock(), MagicMock())
         m_rotate_vel.return_value = (MagicMock(), MagicMock())
+        caplog.set_level(logging.DEBUG)
+
         make_ww3_current_file.make_ww3_current_file(parsed_args, config)
+
         drop_vars = {
             "gphiu",
             "vmask",
@@ -455,18 +472,20 @@ class TestCalcForecastDatasets:
             assert caplog.messages[i] == expected[i]
 
 
-@patch("nowcast.workers.make_ww3_current_file.logger", autospec=True)
 @patch("nowcast.workers.make_ww3_current_file.subprocess.run", autospec=True)
 class TestCalcForecast2Datasets:
     """Unit tests for _calc_forecast2_datasets() function."""
 
-    def test_forecast2_datasets(self, m_run, m_logger):
+    def test_forecast2_datasets(self, m_run, caplog):
+        caplog.set_level(logging.DEBUG)
+
         datasets = make_ww3_current_file._calc_forecast2_datasets(
             arrow.get("2017-04-13"),
             Path("/nemoShare/MEOPAR/SalishSea/"),
             "SalishSea_1h_{s_yyyymmdd}_{e_yyyymmdd}_grid_{grid}.nc",
             Path("/nemoShare/MEOPAR/nowcast-sys/wwatch3-runs/current"),
         )
+
         assert datasets == {
             "u": [
                 Path(

--- a/tests/workers/test_run_NEMO_hindcast.py
+++ b/tests/workers/test_run_NEMO_hindcast.py
@@ -162,7 +162,7 @@ class TestSuccess:
         assert caplog.records[0].levelname == "INFO"
         expected = f"NEMO hindcast run queued on {host_name}"
         assert caplog.records[0].message == expected
-        assert msg_type == f"success"
+        assert msg_type == "success"
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
@@ -178,7 +178,7 @@ class TestFailure:
         assert caplog.records[0].levelname == "CRITICAL"
         expected = f"NEMO hindcast run failed to queue on {host_name}"
         assert caplog.records[0].message == expected
-        assert msg_type == f"failure"
+        assert msg_type == "failure"
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))

--- a/tests/workers/test_run_NEMO_hindcast.py
+++ b/tests/workers/test_run_NEMO_hindcast.py
@@ -17,6 +17,7 @@
 
 
 """Unit tests for SalishSeaCast run_NEMO_hindcast worker."""
+import logging
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -149,31 +150,38 @@ class TestConfig:
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 class TestSuccess:
     """Unit test for success() function."""
 
-    def test_success(self, m_logger, host_name):
+    def test_success(self, host_name, caplog):
         parsed_args = SimpleNamespace(host_name=host_name)
+        caplog.set_level(logging.DEBUG)
+
         msg_type = run_NEMO_hindcast.success(parsed_args)
-        assert m_logger.info.called
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = f"NEMO hindcast run queued on {host_name}"
+        assert caplog.records[0].message == expected
         assert msg_type == f"success"
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 class TestFailure:
     """Unit test for failure() function."""
 
-    def test_failure(self, m_logger, host_name):
+    def test_failure(self, host_name, caplog):
         parsed_args = SimpleNamespace(host_name=host_name)
+        caplog.set_level(logging.DEBUG)
+
         msg_type = run_NEMO_hindcast.failure(parsed_args)
-        assert m_logger.critical.called
+
+        assert caplog.records[0].levelname == "CRITICAL"
+        expected = f"NEMO hindcast run failed to queue on {host_name}"
+        assert caplog.records[0].message == expected
         assert msg_type == f"failure"
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch(
     "nowcast.workers.watch_NEMO_agrif.ssh_sftp.sftp",
     return_value=(Mock(name="ssh_client"), Mock(name="sftp_client")),
@@ -198,16 +206,19 @@ class TestRunNEMO_Hindcast:
         m_get_prev_run_namelist_info,
         m_get_prev_run_queue_info,
         m_sftp,
-        m_logger,
         host_name,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name=host_name, full_month=True, prev_run_date=arrow.get("2019-01-11")
         )
+        caplog.set_level(logging.DEBUG)
+
         with patch("nowcast.workers.run_NEMO_hindcast.arrow.now") as m_now:
             m_now.return_value = arrow.get("2019-01-30")
             checklist = run_NEMO_hindcast.run_NEMO_hindcast(parsed_args, config)
+
         assert not m_launch_run.called
         expected = {"hindcast": {"host": host_name, "run id": "None"}}
         assert checklist == expected
@@ -220,9 +231,9 @@ class TestRunNEMO_Hindcast:
         m_get_prev_run_namelist_info,
         m_get_prev_run_queue_info,
         m_sftp,
-        m_logger,
         host_name,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name=host_name,
@@ -230,9 +241,12 @@ class TestRunNEMO_Hindcast:
             prev_run_date=arrow.get("2019-08-06"),
             walltime=None,
         )
+        caplog.set_level(logging.DEBUG)
+
         with patch("nowcast.workers.run_NEMO_hindcast.arrow.now") as m_now:
             m_now.return_value = arrow.get("2019-08-15")
             checklist = run_NEMO_hindcast.run_NEMO_hindcast(parsed_args, config)
+
         assert m_launch_run.called
         expected = {"hindcast": {"host": host_name, "run id": "11aug19hindcast"}}
         assert checklist == expected
@@ -260,12 +274,12 @@ class TestRunNEMO_Hindcast:
         m_get_prev_run_namelist_info,
         m_get_prev_run_queue_info,
         m_sftp,
-        m_logger,
         host_name,
         full_month,
         prev_run_date,
         expected_run_id,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name=host_name,
@@ -273,7 +287,10 @@ class TestRunNEMO_Hindcast:
             prev_run_date=prev_run_date,
             walltime=None,
         )
+        caplog.set_level(logging.DEBUG)
+
         checklist = run_NEMO_hindcast.run_NEMO_hindcast(parsed_args, config)
+
         expected = {"hindcast": {"host": host_name, "run id": expected_run_id}}
         assert checklist == expected
 
@@ -300,12 +317,12 @@ class TestRunNEMO_Hindcast:
         m_get_prev_run_namelist_info,
         m_get_prev_run_queue_info,
         m_sftp,
-        m_logger,
         host_name,
         full_month,
         prev_run_date,
         expected_run_id,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name=host_name,
@@ -314,7 +331,10 @@ class TestRunNEMO_Hindcast:
             walltime=None,
         )
         m_get_prev_run_queue_info.return_value = (prev_run_date, 12_345_678)
+        caplog.set_level(logging.DEBUG)
+
         checklist = run_NEMO_hindcast.run_NEMO_hindcast(parsed_args, config)
+
         expected = {"hindcast": {"host": host_name, "run id": expected_run_id}}
         assert checklist == expected
 
@@ -344,13 +364,13 @@ class TestRunNEMO_Hindcast:
         m_get_prev_run_namelist_info,
         m_get_prev_run_queue_info,
         m_sftp,
-        m_logger,
         host_name,
         full_month,
         prev_run_date,
         expected_run_date,
         expected_run_days,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name=host_name,
@@ -358,7 +378,10 @@ class TestRunNEMO_Hindcast:
             prev_run_date=prev_run_date,
             walltime=None,
         )
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast.run_NEMO_hindcast(parsed_args, config)
+
         m_edit_namelist_time.assert_called_once_with(
             m_sftp()[1],
             host_name,
@@ -410,7 +433,6 @@ class TestRunNEMO_Hindcast:
         m_get_prev_run_namelist_info,
         m_get_prev_run_queue_info,
         m_sftp,
-        m_logger,
         host_name,
         full_month,
         prev_run_date,
@@ -418,6 +440,7 @@ class TestRunNEMO_Hindcast:
         expected_run_date,
         expected_walltime,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             host_name=host_name,
@@ -425,7 +448,10 @@ class TestRunNEMO_Hindcast:
             prev_run_date=prev_run_date,
             walltime=walltime,
         )
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast.run_NEMO_hindcast(parsed_args, config)
+
         m_edit_run_desc.assert_called_once_with(
             m_sftp()[1],
             host_name,
@@ -437,63 +463,81 @@ class TestRunNEMO_Hindcast:
         )
 
 
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast._get_qstat_queue_info", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast._get_squeue_queue_info", autospec=True)
 class TestGetPrevRunQueueInfo:
     """Unit tests for _get_prev_run_queue_info() function."""
 
     def test_found_prev_hindcast_job_squeue(
-        self, m_squeue_info, m_qstat_info, m_logger, config
+        self, m_squeue_info, m_qstat_info, config, caplog
     ):
         m_squeue_info.return_value = ["12345678 01may18hindcast"]
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         prev_run_date, job_id = run_NEMO_hindcast._get_prev_run_queue_info(
             m_ssh_client, "cedar", config
         )
+
         assert prev_run_date == arrow.get("2018-05-01")
         assert job_id == "12345678"
-        assert m_logger.info.called
+        assert caplog.records[0].levelname == "INFO"
+        expected = "using 01may18hindcast job 12345678 on cedar as previous run"
+        assert caplog.messages[0] == expected
 
     def test_found_prev_hindcast_job_qstat(
-        self, m_squeue_info, m_qstat_info, m_logger, config
+        self, m_squeue_info, m_qstat_info, config, caplog
     ):
         m_qstat_info.return_value = ["12345678.admin 01may18hindcast"]
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         prev_run_date, job_id = run_NEMO_hindcast._get_prev_run_queue_info(
             m_ssh_client, "optimum", config
         )
+
         assert prev_run_date == arrow.get("2018-05-01")
         assert job_id == "12345678.admin"
-        assert m_logger.info.called
+        assert caplog.records[0].levelname == "INFO"
+        expected = "using 01may18hindcast job 12345678.admin on optimum as previous run"
+        assert caplog.messages[0] == expected
 
     @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
     def test_no_prev_hindcast_job_found(
-        self, m_squeue_info, m_qstat_info, m_logger, host_name, config
+        self, m_squeue_info, m_qstat_info, host_name, config, caplog
     ):
         m_qstat_info.return_value = ["12345678.admin 07may18nowcast-agrif"]
         m_squeue_info.return_value = ["12345678 07may18nowcast-agrif"]
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(nemo_nowcast.WorkerError):
             run_NEMO_hindcast._get_prev_run_queue_info(m_ssh_client, host_name, config)
-        assert m_logger.error.called
+
+        assert caplog.records[0].levelname == "ERROR"
+        expected = f"no hindcast jobs found on {host_name} queue"
+        assert caplog.messages[0] == expected
 
 
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.ssh_sftp.ssh_exec_command", autospec=True)
 class TestGetQstatQueueInfo:
     """Unit tests for _get_qstat_queue_info() function."""
 
-    def test_no_job_found_on_queue(self, m_ssh_exec_cmd, m_logger, config):
+    def test_no_job_found_on_queue(self, m_ssh_exec_cmd, config, caplog):
         m_ssh_exec_cmd.return_value = "\n".join(f"header{i}" for i in range(5))
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(nemo_nowcast.WorkerError):
             run_NEMO_hindcast._get_qstat_queue_info(
                 m_ssh_client, "optimum", "/usr/bin/qstat", "sallen,dlatorne"
             )
-        assert m_logger.error.called
 
-    def test_queue_info_lines(self, m_ssh_exec_cmd, m_logger, config):
+        assert caplog.records[0].levelname == "ERROR"
+        expected = "no jobs found on optimum queue"
+        assert caplog.messages[0] == expected
+
+    def test_queue_info_lines(self, m_ssh_exec_cmd, config, caplog):
         qstat_return = "\n".join(f"header{i}" for i in range(5))
         qstat_return = (
             f"{qstat_return}\n"
@@ -502,23 +546,27 @@ class TestGetQstatQueueInfo:
         )
         m_ssh_exec_cmd.return_value = qstat_return
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         queue_info_lines = run_NEMO_hindcast._get_qstat_queue_info(
             m_ssh_client, "optimum", "/usr/bin/qstat", "sallen,dlatorne"
         )
+
         assert queue_info_lines == [
             "12345679 25may19hindcast",
             "12345678 15may19hindcast",
         ]
 
 
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.ssh_sftp.ssh_exec_command", autospec=True)
 class TestGetSqueueQueueInfo:
     """Unit tests for _get_squeue_queue_info() function."""
 
-    def test_no_job_found_on_queue(self, m_ssh_exec_cmd, m_logger, config):
+    def test_no_job_found_on_queue(self, m_ssh_exec_cmd, config, caplog):
         m_ssh_exec_cmd.return_value = "header\n"
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(nemo_nowcast.WorkerError):
             run_NEMO_hindcast._get_squeue_queue_info(
                 m_ssh_client,
@@ -526,16 +574,22 @@ class TestGetSqueueQueueInfo:
                 "/opt/software/slurm/bin/squeue",
                 "allen,dlatorne",
             )
-        assert m_logger.error.called
 
-    def test_queue_info_lines(self, m_ssh_exec_cmd, m_logger, config):
+        assert caplog.records[0].levelname == "ERROR"
+        expected = "no jobs found on optimum queue"
+        assert caplog.messages[0] == expected
+
+    def test_queue_info_lines(self, m_ssh_exec_cmd, config, caplog):
         m_ssh_exec_cmd.return_value = (
             "header\n12345678 15may19hindcast\n12345679 25may19hindcast\n"
         )
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         queue_info_lines = run_NEMO_hindcast._get_squeue_queue_info(
             m_ssh_client, "optimum", "/opt/software/slurm/bin/squeue", "allen,dlatorne"
         )
+
         assert queue_info_lines == [
             "12345679 25may19hindcast",
             "12345678 15may19hindcast",
@@ -543,14 +597,13 @@ class TestGetSqueueQueueInfo:
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.ssh_sftp.ssh_exec_command", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.f90nml.read", autospec=True)
 class TestGetPrevRunNamelistInfo:
     """Unit test for _get_prev_run_namelist_info() function."""
 
     def test_get_prev_run_namelist_info(
-        self, m_f90nml_read, m_ssh_exec_cmd, m_logger, host_name, config
+        self, m_f90nml_read, m_ssh_exec_cmd, host_name, config, caplog
     ):
         m_ssh_client = Mock(name="ssh_client")
         m_sftp_client = Mock(name="sftp_client")
@@ -563,30 +616,39 @@ class TestGetPrevRunNamelistInfo:
             "namrun": {"nn_itend": 2_717_280},
             "namdom": {"rn_rdt": 40.0},
         }
+        caplog.set_level(logging.DEBUG)
+
         with p_named_tmp_file as m_named_tmp_file:
             prev_namelist_info = run_NEMO_hindcast._get_prev_run_namelist_info(
                 m_ssh_client, m_sftp_client, host_name, arrow.get("2018-05-01"), config
             )
+
         m_ssh_exec_cmd.assert_called_once_with(
-            m_ssh_client, "ls -d scratch/01may18*/namelist_cfg", host_name, m_logger
+            m_ssh_client,
+            "ls -d scratch/01may18*/namelist_cfg",
+            host_name,
+            run_NEMO_hindcast.logger,
         )
         m_sftp_client.get.assert_called_once_with(
             "scratch/01may18hindcast_xxx/namelist_cfg",
             m_named_tmp_file().__enter__().name,
         )
-        assert m_logger.info.called
+        assert caplog.records[0].levelname == "INFO"
+        expected = f"found previous run namelist: {host_name}:scratch/01may18hindcast_xxx/namelist_cfg"
+        assert caplog.messages[0] == expected
         assert prev_namelist_info == SimpleNamespace(itend=2_717_280, rdt=40.0)
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.f90nml.patch", autospec=True)
 class TestEditNamelistTime:
     """Unit tests for _edit_namelist_time() function."""
 
-    def test_download_namelist_time(self, m_patch, m_logger, host_name, config):
+    def test_download_namelist_time(self, m_patch, host_name, config, caplog):
         m_sftp_client = Mock(name="sftp_client")
         prev_namelist_info = SimpleNamespace(itend=2_717_280, rdt=40.0)
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._edit_namelist_time(
             m_sftp_client,
             host_name,
@@ -595,6 +657,7 @@ class TestEditNamelistTime:
             28,
             config,
         )
+
         m_sftp_client.get.assert_called_once_with(
             "runs/namelist.time", "/tmp/hindcast.namelist.time"
         )
@@ -661,19 +724,22 @@ class TestEditNamelistTime:
     def test_patch_namelist_time(
         self,
         m_patch,
-        m_logger,
         host_name,
         run_date,
         run_days,
         expected_itend,
         expected_stocklist,
         config,
+        caplog,
     ):
         sftp_client = Mock(name="sftp_client")
         prev_namelist_info = SimpleNamespace(itend=2_717_280, rdt=40.0)
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._edit_namelist_time(
             sftp_client, host_name, prev_namelist_info, run_date, run_days, config
         )
+
         m_patch.assert_called_once_with(
             "/tmp/hindcast.namelist.time",
             {
@@ -687,9 +753,11 @@ class TestEditNamelistTime:
             "/tmp/patched_hindcast.namelist.time",
         )
 
-    def test_upload_namelist_time(self, m_patch, m_logger, host_name, config):
+    def test_upload_namelist_time(self, m_patch, host_name, config, caplog):
         m_sftp_client = Mock(name="sftp_client")
         prev_namelist_info = SimpleNamespace(itend=2_717_280, rdt=40.0)
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._edit_namelist_time(
             m_sftp_client,
             host_name,
@@ -698,13 +766,13 @@ class TestEditNamelistTime:
             28,
             config,
         )
+
         m_sftp_client.put.assert_called_once_with(
             "/tmp/patched_hindcast.namelist.time", "runs/namelist.time"
         )
 
 
 @pytest.mark.parametrize("host_name", ("cedar", "optimum"))
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch(
     "nowcast.workers.run_NEMO_agrif.yaml.safe_load",
     return_value={
@@ -718,11 +786,13 @@ class TestEditRunDesc:
     """Unit tests for _edit_run_desc() function."""
 
     def test_download_run_desc_template(
-        self, m_safe_load, m_logger, host_name, tmpdir, config
+        self, m_safe_load, host_name, tmpdir, config, caplog
     ):
         m_sftp_client = Mock(name="sftp_client")
         prev_namelist_info = SimpleNamespace(itend=2_717_280, rdt=40.0)
         yaml_tmpl = tmpdir.ensure("hindcast_tmpl.yaml")
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._edit_run_desc(
             m_sftp_client,
             host_name,
@@ -733,6 +803,7 @@ class TestEditRunDesc:
             config,
             yaml_tmpl=Path(str(yaml_tmpl)),
         )
+
         m_sftp_client.get.assert_called_once_with(
             "runs/hindcast_template.yaml", yaml_tmpl
         )
@@ -740,11 +811,13 @@ class TestEditRunDesc:
     @pytest.mark.parametrize("walltime", ["03:00:00", "08:30:00", "12:00:00"])
     @patch("nowcast.workers.run_NEMO_hindcast.yaml.safe_dump", autospec=True)
     def test_edit_run_desc(
-        self, m_safe_dump, m_safe_load, m_logger, walltime, host_name, tmpdir, config
+        self, m_safe_dump, m_safe_load, walltime, host_name, tmpdir, config, caplog
     ):
         m_sftp_client = Mock(name="sftp_client")
         prev_namelist_info = SimpleNamespace(itend=2_717_280, rdt=40.0)
         yaml_tmpl = tmpdir.ensure("hindcast_tmpl.yaml")
+        caplog.set_level(logging.DEBUG)
+
         with patch("nowcast.workers.run_NEMO_hindcast.Path.open") as m_open:
             run_NEMO_hindcast._edit_run_desc(
                 m_sftp_client,
@@ -756,6 +829,7 @@ class TestEditRunDesc:
                 config,
                 yaml_tmpl=Path(str(yaml_tmpl)),
             )
+
         m_safe_dump.assert_called_once_with(
             {
                 "run_id": "01jun18hindcast",
@@ -769,10 +843,12 @@ class TestEditRunDesc:
             default_flow_style=False,
         )
 
-    def test_upload_run_desc(self, m_safe_load, m_logger, host_name, tmpdir, config):
+    def test_upload_run_desc(self, m_safe_load, host_name, tmpdir, config, caplog):
         m_sftp_client = Mock(name="sftp_client")
         prev_namelist_info = SimpleNamespace(itend=2_717_280, rdt=40.0)
         yaml_tmpl = tmpdir.ensure("hindcast_tmpl.yaml")
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._edit_run_desc(
             m_sftp_client,
             host_name,
@@ -783,6 +859,7 @@ class TestEditRunDesc:
             config,
             yaml_tmpl=Path(str(yaml_tmpl)),
         )
+
         m_sftp_client.put.assert_called_once_with(
             yaml_tmpl, "runs/01feb18hindcast.yaml"
         )
@@ -800,30 +877,34 @@ class TestEditRunDesc:
         ),
     ),
 )
-@patch("nowcast.workers.run_NEMO_hindcast.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.ssh_sftp.ssh_exec_command", autospec=True)
 class TestLaunchRun:
     """Unit tests for _launch_run() function."""
 
     def test_launch_run(
-        self, m_ssh_exec_cmd, m_logger, host_name, run_opts, envvars, config
+        self, m_ssh_exec_cmd, host_name, run_opts, envvars, config, caplog
     ):
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._launch_run(
             m_ssh_client, host_name, "01may18hindcast", prev_job_id=None, config=config
         )
+
         m_ssh_exec_cmd.assert_called_once_with(
             m_ssh_client,
             f"{envvars}bin/salishsea run runs/01may18hindcast.yaml scratch/01may18 "
             f"{run_opts}",
             host_name,
-            m_logger,
+            run_NEMO_hindcast.logger,
         )
 
     def test_launch_run_with_prev_job_id(
-        self, m_ssh_exec_cmd, m_logger, host_name, run_opts, envvars, config
+        self, m_ssh_exec_cmd, host_name, run_opts, envvars, config, caplog
     ):
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         run_NEMO_hindcast._launch_run(
             m_ssh_client,
             host_name,
@@ -831,22 +912,25 @@ class TestLaunchRun:
             prev_job_id=12_345_678,
             config=config,
         )
+
         m_ssh_exec_cmd.assert_called_once_with(
             m_ssh_client,
             f"{envvars}bin/salishsea run runs/01may18hindcast.yaml scratch/01may18 "
             f"{run_opts} "
             f"--waitjob 12345678 --nocheck-initial-conditions",
             host_name,
-            m_logger,
+            run_NEMO_hindcast.logger,
         )
 
     def test_ssh_error(
-        self, m_ssh_exec_cmd, m_logger, host_name, run_opts, envvars, config
+        self, m_ssh_exec_cmd, host_name, run_opts, envvars, config, caplog
     ):
         m_ssh_client = Mock(name="ssh_client")
         m_ssh_exec_cmd.side_effect = nowcast.ssh_sftp.SSHCommandError(
             "cmd", "stdout", "stderr"
         )
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(nemo_nowcast.WorkerError):
             run_NEMO_hindcast._launch_run(
                 m_ssh_client,
@@ -855,4 +939,6 @@ class TestLaunchRun:
                 prev_job_id=None,
                 config=config,
             )
-        m_logger.error.assert_called_once_with("stderr")
+
+        assert caplog.records[0].levelname == "ERROR"
+        assert caplog.messages[0] == "stderr"

--- a/tests/workers/test_watch_NEMO_agrif.py
+++ b/tests/workers/test_watch_NEMO_agrif.py
@@ -17,6 +17,7 @@
 
 
 """Unit tests for SalishSeaCast watch_NEMO_agrif worker."""
+import logging
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -77,29 +78,37 @@ class TestMain:
         assert worker.cli.parser._actions[4].help
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 class TestSuccess:
     """Unit test for success() function."""
 
-    def test_success(self, m_logger):
+    def test_success(self, caplog):
         parsed_args = SimpleNamespace(host_name="orcinus", job_id="9305855.orca2.ibb")
+
+        caplog.set_level(logging.DEBUG)
+
         msg_type = watch_NEMO_agrif.success(parsed_args)
-        assert m_logger.info.called
-        assert msg_type == f"success"
+
+        assert caplog.records[0].levelname == "INFO"
+        expected = f"NEMO AGRIF run 9305855.orca2.ibb on orcinus completed"
+        assert caplog.messages[0] == expected
+        assert msg_type == "success"
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 class TestFailure:
     """Unit test for failure() function."""
 
-    def test_failure(self, m_logger):
+    def test_failure(self, caplog):
         parsed_args = SimpleNamespace(host_name="orcinus", job_id="9305855.orca2.ibb")
+        caplog.set_level(logging.DEBUG)
+
         msg_type = watch_NEMO_agrif.failure(parsed_args)
-        assert m_logger.critical.called
-        assert msg_type == f"failure"
+
+        assert caplog.records[0].levelname == "CRITICAL"
+        expected = f"NEMO AGRIF run 9305855.orca2.ibb on orcinus watcher failed"
+        assert caplog.messages[0] == expected
+        assert msg_type == "failure"
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 @patch(
     "nowcast.workers.watch_NEMO_agrif.ssh_sftp.sftp",
     return_value=(Mock(name="ssh_client"), Mock(name="sftp_client")),
@@ -135,11 +144,14 @@ class TestWatchNEMO_AGRIF:
         m_is_queued,
         m_get_run_id,
         m_sftp,
-        m_logger,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(host_name="orcinus", job_id="9305855.orca2.ibb")
+        caplog.set_level(logging.DEBUG)
+
         checklist = watch_NEMO_agrif.watch_NEMO_agrif(parsed_args, config)
+
         expected = {
             "nowcast-agrif": {
                 "host": "orcinus",
@@ -151,7 +163,6 @@ class TestWatchNEMO_AGRIF:
         assert checklist == expected
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 @patch(
     "nowcast.workers.watch_NEMO_agrif._get_queue_info",
     return_value="Job_Name = 23apr18nowcast-agrif\n",
@@ -160,15 +171,19 @@ class TestWatchNEMO_AGRIF:
 class TestGetRunId:
     """Unit test for _get_run_id() function."""
 
-    def test_get_run_id(self, m_get_queue_info, m_logger):
+    def test_get_run_id(self, m_get_queue_info, caplog):
         ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         run_id = watch_NEMO_agrif._get_run_id(ssh_client, "orcinus", "9305855")
+
         m_get_queue_info.assert_called_once_with(ssh_client, "orcinus", "9305855")
-        assert m_logger.info.called
+        assert caplog.records[0].levelname == "INFO"
+        expected = f"watching 23apr18nowcast-agrif job 9305855 on orcinus"
+        assert caplog.messages[0] == expected
         assert run_id == "23apr18nowcast-agrif"
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 @patch("nowcast.workers.watch_NEMO_agrif._get_queue_info", autospec=True)
 class TestIsQueued:
     """Unit test for _is_queued() function."""
@@ -176,31 +191,37 @@ class TestIsQueued:
     @pytest.mark.parametrize(
         "queue_info, expected", [("job_state = Q\n", True), ("job_state = R\n", False)]
     )
-    def test_is_queued(self, m_get_queue_info, m_logger, queue_info, expected):
+    def test_is_queued(self, m_get_queue_info, queue_info, expected, caplog):
         m_get_queue_info.return_value = queue_info
         ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         is_queued = watch_NEMO_agrif._is_queued(
             ssh_client, "orcinus", "9305855", "24apr18nowcast-agrif"
         )
+
         m_get_queue_info.assert_called_once_with(ssh_client, "orcinus", "9305855")
         if expected:
-            assert m_logger.info.called
+            assert caplog.records[0].levelname == "INFO"
+            expected = f"24apr18nowcast-agrif job 9305855 is queued on orcinus"
+            assert caplog.messages[0] == expected
             assert is_queued
         else:
             assert not is_queued
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 @patch("nowcast.workers.watch_NEMO_agrif._get_queue_info", autospec=True)
 class TestIsRunning:
     """Unit test for _is_running() function."""
 
-    def test_job_not_on_queue(self, m_get_queue_info, m_logger):
+    def test_job_not_on_queue(self, m_get_queue_info, caplog):
         m_get_queue_info.return_value = "job_state = UNKNOWN\n"
         ssh_client = Mock(name="ssh_client")
         run_info = SimpleNamespace(
             it000=2_360_881, itend=2_363_040, date0=arrow.get("2018-04-24"), rdt=40
         )
+        caplog.set_level(logging.DEBUG)
+
         is_running = watch_NEMO_agrif._is_running(
             ssh_client,
             "orcinus",
@@ -209,6 +230,7 @@ class TestIsRunning:
             Path("tmp_run_dir"),
             run_info,
         )
+
         m_get_queue_info.assert_called_once_with(
             ssh_client, "orcinus", "9305855", ignore_unknown_job=True
         )
@@ -223,13 +245,15 @@ class TestIsRunning:
         autospec=True,
     )
     def test_is_running(
-        self, m_ssh_exec_command, m_get_queue_info, m_logger, queue_info, expected
+        self, m_ssh_exec_command, m_get_queue_info, queue_info, expected, caplog
     ):
         m_get_queue_info.return_value = queue_info
         ssh_client = Mock(name="ssh_client")
         run_info = SimpleNamespace(
             it000=2_360_881, itend=2_363_040, date0=arrow.get("2018-04-24"), rdt=40
         )
+        caplog.set_level(logging.DEBUG)
+
         is_running = watch_NEMO_agrif._is_running(
             ssh_client,
             "orcinus",
@@ -238,11 +262,14 @@ class TestIsRunning:
             Path("tmp_run_dir"),
             run_info,
         )
+
         m_get_queue_info.assert_called_once_with(
             ssh_client, "orcinus", "9305855", ignore_unknown_job=True
         )
         if expected:
-            assert m_logger.info.called
+            assert caplog.records[0].levelname == "INFO"
+            expected = f"24apr18nowcast-agrif on orcinus: timestep: 2361000 = 2018-04-24 01:19:20 UTC, 5.5% complete"
+            assert caplog.messages[0] == expected
             assert is_running
         else:
             assert not is_running
@@ -252,12 +279,14 @@ class TestIsRunning:
         side_effect=nowcast.ssh_sftp.SSHCommandError("cmd", "stdout", "stderr"),
         autospec=True,
     )
-    def test_no_time_step_file(self, m_ssh_exec_command, m_get_queue_info, m_logger):
+    def test_no_time_step_file(self, m_ssh_exec_command, m_get_queue_info, caplog):
         m_get_queue_info.return_value = "job_state = R\n"
         ssh_client = Mock(name="ssh_client")
         run_info = SimpleNamespace(
             it000=2_360_881, itend=2_363_040, date0=arrow.get("2018-04-24"), rdt=40
         )
+        caplog.set_level(logging.DEBUG)
+
         is_running = watch_NEMO_agrif._is_running(
             ssh_client,
             "orcinus",
@@ -266,14 +295,16 @@ class TestIsRunning:
             Path("tmp_run_dir"),
             run_info,
         )
+
         m_get_queue_info.assert_called_once_with(
             ssh_client, "orcinus", "9305855", ignore_unknown_job=True
         )
-        assert m_logger.info.called
+        assert caplog.records[0].levelname == "INFO"
+        expected = f"24apr18nowcast-agrif on orcinus: time.step not found; continuing to watch..."
+        assert caplog.messages[0] == expected
         assert is_running
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 class TestGetQueueInfo:
     """Unit tests for _get_queue_info() function."""
 
@@ -282,14 +313,17 @@ class TestGetQueueInfo:
         return_value="job_state = R\n",
         autospec=True,
     )
-    def test_get_queue_info(self, m_ssh_exec_cmd, m_logger):
+    def test_get_queue_info(self, m_ssh_exec_cmd, caplog):
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         stdout = watch_NEMO_agrif._get_queue_info(m_ssh_client, "orcinus", "9305855")
+
         m_ssh_exec_cmd.assert_called_once_with(
             m_ssh_client,
             "/global/system/torque/bin/qstat -f -1 9305855",
             "orcinus",
-            m_logger,
+            watch_NEMO_agrif.logger,
         )
         assert stdout == "job_state = R\n"
 
@@ -298,10 +332,14 @@ class TestGetQueueInfo:
         side_effect=nowcast.ssh_sftp.SSHCommandError("cmd", "stdout", "stderr"),
         autospec=True,
     )
-    def test_ssh_error(self, m_ssh_exec_cmd, m_logger):
+    def test_ssh_error(self, m_ssh_exec_cmd, caplog):
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         with pytest.raises(nemo_nowcast.WorkerError):
             watch_NEMO_agrif._get_queue_info(m_ssh_client, "orcinus", "9305855")
+        assert caplog.records[0].levelname == "ERROR"
+        assert caplog.messages[0] == "stderr"
 
     @patch(
         "nowcast.workers.watch_NEMO_agrif.ssh_sftp.ssh_exec_command",
@@ -310,15 +348,17 @@ class TestGetQueueInfo:
         ),
         autospec=True,
     )
-    def test_ignore_unknown_job(self, m_ssh_exec_cmd, m_logger):
+    def test_ignore_unknown_job(self, m_ssh_exec_cmd, caplog):
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         stdout = watch_NEMO_agrif._get_queue_info(
             m_ssh_client, "orcinus", "9305855", ignore_unknown_job=True
         )
+
         assert stdout == "job_state = UNKNOWN\n"
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 @patch(
     "nowcast.workers.watch_NEMO_agrif.ssh_sftp.ssh_exec_command",
     return_value="scratch/07may18nowcast-agrif_xxx\n",
@@ -327,24 +367,31 @@ class TestGetQueueInfo:
 class TestGetTmpRunDir:
     """Unit test for _get_tmp_run_dir() functions."""
 
-    def test_get_tmp_run_dir(self, m_ssh_exec_cmd, m_logger):
+    def test_get_tmp_run_dir(self, m_ssh_exec_cmd, caplog):
         m_ssh_client = Mock(name="ssh_client")
+        caplog.set_level(logging.DEBUG)
+
         tmp_run_dir = watch_NEMO_agrif._get_tmp_run_dir(
             m_ssh_client, "orcinus", Path("scratch"), "07may18nowcast-agrif"
         )
+
         m_ssh_exec_cmd.assert_called_once_with(
-            m_ssh_client, "ls -d scratch/07may18nowcast-agrif_*", "orcinus", m_logger
+            m_ssh_client,
+            "ls -d scratch/07may18nowcast-agrif_*",
+            "orcinus",
+            watch_NEMO_agrif.logger,
         )
-        assert m_logger.debug.called
+        assert caplog.records[0].levelname == "DEBUG"
+        expected = "found tmp run dir: orcinus:scratch/07may18nowcast-agrif_xxx"
+        assert caplog.messages[0] == expected
         assert tmp_run_dir == Path("scratch/07may18nowcast-agrif_xxx")
 
 
-@patch("nowcast.workers.watch_NEMO_agrif.logger", autospec=True)
 @patch("nowcast.workers.run_NEMO_hindcast.f90nml.read", autospec=True)
 class TestGetRunInfo:
     """Unit test for _get_run_info() function."""
 
-    def test_get_run_info(self, m_f90nml_read, m_logger):
+    def test_get_run_info(self, m_f90nml_read, caplog):
         m_sftp_client = Mock(name="sftp_client")
         p_named_tmp_file = patch(
             "nowcast.workers.watch_NEMO_agrif.tempfile.NamedTemporaryFile",
@@ -358,15 +405,20 @@ class TestGetRunInfo:
             },
             "namdom": {"rn_rdt": 40.0},
         }
+        caplog.set_level(logging.DEBUG)
+
         with p_named_tmp_file as m_named_tmp_file:
             run_info = watch_NEMO_agrif._get_run_info(
                 m_sftp_client, "orcinus", Path("scratch/07may18nowcst-agrif_xxx")
             )
+
         m_sftp_client.get.assert_called_once_with(
             "scratch/07may18nowcst-agrif_xxx/namelist_cfg",
             m_named_tmp_file().__enter__().name,
         )
-        assert m_logger.debug.called
+        assert caplog.records[0].levelname == "DEBUG"
+        expected = "downloaded orcinus:scratch/07may18nowcst-agrif_xxx/namelist_cfg"
+        assert caplog.messages[0] == expected
         assert run_info == SimpleNamespace(
             it000=2_360_881, itend=2_363_040, date0=arrow.get("2018-05-08"), rdt=40.0
         )


### PR DESCRIPTION
Replaced mocked loggers with `caplog` in unit tests for better clarity and alignment with pytest practices. Updated assertions to check log levels and messages directly via `caplog`, improving test reliability and readability.

re: issue #82