### PR TITLE
Handle 400 HTTP error in `get_onc_ferry` worker

### DIFF
--- a/nowcast/workers/get_onc_ferry.py
+++ b/nowcast/workers/get_onc_ferry.py
@@ -124,14 +124,14 @@ def get_onc_ferry(parsed_args, config, *args):
             "chunksizes": [dataset.time.size],
         }
     }
-    encoding.update({var: {"chunksizes": [dataset[var].size]} for var in dataset})
-    encoding.update(
-        {
-            var: {"dtype": "int32", "_FillValue": 0, "chunksizes": [dataset[var].size]}
-            for var in dataset
-            if var.endswith("sample_count")
-        }
-    )
+    chunksizes = {var: {"chunksizes": [dataset[var].size]} for var in dataset}
+    encoding.update(**chunksizes)
+    sample_counts_encoding = {
+        var: {"dtype": "int32", "_FillValue": 0, "chunksizes": [dataset[var].size]}
+        for var in dataset
+        if var.endswith("sample_count")
+    }
+    encoding.update(**sample_counts_encoding)
     dataset.to_netcdf(
         os.fspath(nc_filepath), encoding=encoding, unlimited_dims=("time",)
     )
@@ -144,18 +144,21 @@ def _get_nav_data(ferry_platform, ymd, location_config):
         device_category = location_config["device category"]
         sensors = ",".join(location_config["sensors"])
         logger.info(f"requesting ONC {station} {device_category} data for {ymd}")
+        query_params = {
+            "locationCode": station,
+            "deviceCategoryCode": device_category,
+            "sensorCategoryCodes": sensors,
+            "dateFrom": data_tools.onc_datetime(f"{ymd} 00:00", "utc"),
+            "dateTo": data_tools.onc_datetime(f"{ymd} 23:59", "utc"),
+            "resampleType": "avg",
+            "resamplePeriod": 1,
+        }
         try:
             onc_data = data_tools.get_onc_data(
                 "scalardata",
                 "getByLocation",
                 os.environ["ONC_USER_TOKEN"],
-                locationCode=station,
-                deviceCategoryCode=device_category,
-                sensorCategoryCodes=sensors,
-                dateFrom=(data_tools.onc_datetime(f"{ymd} 00:00", "utc")),
-                dateTo=data_tools.onc_datetime(f"{ymd} 23:59", "utc"),
-                resampleType="avg",
-                resamplePeriod=1,
+                **query_params,
             )
         except requests.HTTPError as e:
             msg = (
@@ -259,18 +262,21 @@ def _calc_crossing_numbers(on_crossing_mask):
 def _get_water_data(ferry_platform, device_category, ymd, devices_config):
     sensors = ",".join(devices_config[device_category]["sensors"].values())
     logger.info(f"requesting ONC {ferry_platform} {device_category} data for {ymd}")
+    query_params = {
+        "locationCode": ferry_platform,
+        "deviceCategoryCode": device_category,
+        "sensorCategoryCodes": sensors,
+        "dateFrom": data_tools.onc_datetime(f"{ymd} 00:00", "utc"),
+        "dateTo": data_tools.onc_datetime(f"{ymd} 23:59", "utc"),
+        "resampleType": "avg",
+        "resamplePeriod": 1,
+    }
     try:
         onc_data = data_tools.get_onc_data(
             "scalardata",
             "getByLocation",
             os.environ["ONC_USER_TOKEN"],
-            locationCode=ferry_platform,
-            deviceCategoryCode=device_category,
-            sensorCategoryCodes=sensors,
-            dateFrom=data_tools.onc_datetime(f"{ymd} 00:00", "utc"),
-            dateTo=data_tools.onc_datetime(f"{ymd} 23:59", "utc"),
-            resampleType="avg",
-            resamplePeriod=1,
+            **query_params,
         )
     except requests.HTTPError as e:
         if e.response.status_code in (400, 504):

--- a/nowcast/workers/get_onc_ferry.py
+++ b/nowcast/workers/get_onc_ferry.py
@@ -273,7 +273,7 @@ def _get_water_data(ferry_platform, device_category, ymd, devices_config):
             resamplePeriod=1,
         )
     except requests.HTTPError as e:
-        if e.response.status_code == 504:
+        if e.response.status_code in (400, 504):
             return _empty_device_data(ferry_platform, device_category, ymd, sensors)
         else:
             logger.error(


### PR DESCRIPTION
This Pull Request refactors and enhances functionality in get_onc_ferry.py to improve code modularity by introducing reusable query parameters for API calls and handling HTTP 400 errors. Additionally, it updates unit tests to test new error-handling logic and accommodate the configuration changes.

## Main Changes

### Refactoring in get_onc_ferry.py:

- Added error handling for HTTP 400 responses in _get_water_data.
- Simplified the encoding logic by creating intermediate variables for better readability and reduced redundancy.
- Replaced direct API parameters with a query_params dictionary to enhance maintainability and reusability.

### Unit Test Enhancements in test_get_onc_ferry.py:

- Expanded fixture config to include new configuration items for ferry sensor and routing details.
- Added new test case test_get_water_data_http_error to handle HTTP 400 and 504 errors, ensuring proper fallback behavior is tested.