### PR TITLE
Refactor test fixtures to add type annotations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@
 
 """Fixtures for SalishSeaCast test suite."""
 from pathlib import Path
+import textwrap
+from typing import Mapping
 from unittest.mock import patch
 
 import attr
@@ -27,23 +29,25 @@ import structlog
 
 
 @pytest.fixture()
-def base_config(tmpdir):
+def base_config(tmp_path: Path) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment containing elements
     required by all unit tests.
     """
-    p = tmpdir.join("config.yaml")
-    p.write(
-        """
-# Items required by the Config instance
-checklist file: nowcast_checklist.yaml
-python: python
-logging:
-  handlers: []
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        textwrap.dedent(
+            """
+            # Items required by the Config instance
+            checklist file: nowcast_checklist.yaml
+            python: python
+            logging:
+              handlers: []
 
-"""
+            """
+        )
     )
     config_ = nemo_nowcast.Config()
-    config_.load(str(p))
+    config_.load(config_file)
     return config_
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ import pytest
 import structlog
 
 
-@pytest.fixture()
+@pytest.fixture
 def base_config(tmp_path: Path) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from a YAML fragment containing the elements
     required by all unit tests.
@@ -50,7 +50,7 @@ def base_config(tmp_path: Path) -> nemo_nowcast.Config | Mapping:
     return config_
 
 
-@pytest.fixture()
+@pytest.fixture
 def prod_config(tmp_path, monkeypatch):
     """:py:class:`nemo_nowcast.Config` instance from the production config YAML file to use for
     testing its contents.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ import structlog
 
 @pytest.fixture()
 def base_config(tmp_path: Path) -> nemo_nowcast.Config | Mapping:
-    """:py:class:`nemo_nowcast.Config` instance from YAML fragment containing elements
+    """:py:class:`nemo_nowcast.Config` instance from a YAML fragment containing the elements
     required by all unit tests.
     """
     config_file = tmp_path / "config.yaml"
@@ -52,13 +52,15 @@ def base_config(tmp_path: Path) -> nemo_nowcast.Config | Mapping:
 
 
 @pytest.fixture()
-def prod_config(tmpdir):
-    """:py:class:`nemo_nowcast.Config` instance from production config YAML file to use for
+def prod_config(tmp_path):
+    """:py:class:`nemo_nowcast.Config` instance from the production config YAML file to use for
     testing its contents.
     """
     prod_config_ = nemo_nowcast.Config()
-    p_logs_dir = tmpdir.ensure_dir("nowcast_logs")
-    p_env_dir = tmpdir.ensure_dir("nowcast-env")
+    p_logs_dir = tmp_path / "nowcast_logs"
+    p_logs_dir.mkdir()
+    p_env_dir = tmp_path / "nowcast-env"
+    p_env_dir.mkdir()
     p_environ = patch.dict(
         nemo_nowcast.config.os.environ,
         {"NOWCAST_LOGS": str(p_logs_dir), "NOWCAST_ENV": str(p_env_dir)},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@
 from pathlib import Path
 import textwrap
 from typing import Mapping
-from unittest.mock import patch
 
 import attr
 import nemo_nowcast
@@ -52,7 +51,7 @@ def base_config(tmp_path: Path) -> nemo_nowcast.Config | Mapping:
 
 
 @pytest.fixture()
-def prod_config(tmp_path):
+def prod_config(tmp_path, monkeypatch):
     """:py:class:`nemo_nowcast.Config` instance from the production config YAML file to use for
     testing its contents.
     """
@@ -61,13 +60,13 @@ def prod_config(tmp_path):
     p_logs_dir.mkdir()
     p_env_dir = tmp_path / "nowcast-env"
     p_env_dir.mkdir()
-    p_environ = patch.dict(
-        nemo_nowcast.config.os.environ,
-        {"NOWCAST_LOGS": str(p_logs_dir), "NOWCAST_ENV": str(p_env_dir)},
-    )
+
+    monkeypatch.setenv("NOWCAST_LOGS", str(p_logs_dir))
+    monkeypatch.setenv("NOWCAST_ENV", str(p_env_dir))
+
     prod_config_file = (Path(__file__).parent / "../config/nowcast.yaml").resolve()
-    with p_environ:
-        prod_config_.load(prod_config_file)
+    prod_config_.load(prod_config_file)
+
     return prod_config_
 
 

--- a/tests/test_daily_river_flows.py
+++ b/tests/test_daily_river_flows.py
@@ -33,7 +33,7 @@ from nowcast import daily_river_flows
 
 
 @pytest.fixture
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | dict:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/test_daily_river_flows.py
+++ b/tests/test_daily_river_flows.py
@@ -32,7 +32,7 @@ import xarray
 from nowcast import daily_river_flows
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -18,8 +18,9 @@
 
 """Unit tests for nowcast.next_workers module."""
 import inspect
-import textwrap
 from pathlib import Path
+import textwrap
+from typing import Mapping
 
 import arrow
 import nemo_nowcast
@@ -30,13 +31,13 @@ from nowcast import next_workers, workers
 
 
 @pytest.fixture
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:
         f.write(
             textwrap.dedent(
-                """\
+                """
                 rivers:
                   stations:
                     ECCC:

--- a/tests/workers/test_archive_tarball.py
+++ b/tests/workers/test_archive_tarball.py
@@ -30,7 +30,7 @@ import pytest
 from nowcast.workers import archive_tarball
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_collect_NeahBay_ssh.py
+++ b/tests/workers/test_collect_NeahBay_ssh.py
@@ -30,7 +30,7 @@ import pytest
 from nowcast.workers import collect_NeahBay_ssh
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -33,7 +33,7 @@ from nemo_nowcast import WorkerError
 from nowcast.workers import collect_river_data
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_collect_weather.py
+++ b/tests/workers/test_collect_weather.py
@@ -23,6 +23,7 @@ import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Mapping
 
 import arrow
 import attr
@@ -33,7 +34,7 @@ from nowcast.workers import collect_weather
 
 
 @pytest.fixture()
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/workers/test_collect_weather.py
+++ b/tests/workers/test_collect_weather.py
@@ -33,7 +33,7 @@ import pytest
 from nowcast.workers import collect_weather
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_crop_gribs.py
+++ b/tests/workers/test_crop_gribs.py
@@ -35,7 +35,7 @@ import xarray
 from nowcast.workers import crop_gribs
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_crop_gribs.py
+++ b/tests/workers/test_crop_gribs.py
@@ -23,6 +23,7 @@ import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Mapping
 
 import arrow
 import attr
@@ -35,7 +36,7 @@ from nowcast.workers import crop_gribs
 
 
 @pytest.fixture()
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/workers/test_download_live_ocean.py
+++ b/tests/workers/test_download_live_ocean.py
@@ -32,7 +32,7 @@ import pytest
 from nowcast.workers import download_live_ocean
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_download_live_ocean.py
+++ b/tests/workers/test_download_live_ocean.py
@@ -23,6 +23,7 @@ import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Mapping
 
 import arrow
 import nemo_nowcast
@@ -32,7 +33,7 @@ from nowcast.workers import download_live_ocean
 
 
 @pytest.fixture()
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/workers/test_download_results.py
+++ b/tests/workers/test_download_results.py
@@ -33,7 +33,7 @@ from nowcast import lib
 from nowcast.workers import download_results
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_download_results.py
+++ b/tests/workers/test_download_results.py
@@ -22,6 +22,7 @@ import shlex
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Mapping
 from unittest.mock import patch
 
 import arrow
@@ -33,7 +34,7 @@ from nowcast.workers import download_results
 
 
 @pytest.fixture()
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | Mapping:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/workers/test_download_weather.py
+++ b/tests/workers/test_download_weather.py
@@ -30,7 +30,7 @@ import pytest
 from nowcast.workers import download_weather
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_download_wwatch3_results.py
+++ b/tests/workers/test_download_wwatch3_results.py
@@ -26,7 +26,7 @@ import pytest
 from nowcast.workers import download_wwatch3_results
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     return base_config

--- a/tests/workers/test_get_onc_ctd.py
+++ b/tests/workers/test_get_onc_ctd.py
@@ -27,7 +27,7 @@ import pytest
 from nowcast.workers import get_onc_ctd
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     return base_config

--- a/tests/workers/test_get_onc_ferry.py
+++ b/tests/workers/test_get_onc_ferry.py
@@ -33,7 +33,7 @@ import xarray
 from nowcast.workers import get_onc_ferry
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_get_vfpa_hadcp.py
+++ b/tests/workers/test_get_vfpa_hadcp.py
@@ -31,7 +31,7 @@ import xarray
 from nowcast.workers import get_vfpa_hadcp
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_grib_to_netcdf.py
+++ b/tests/workers/test_grib_to_netcdf.py
@@ -31,7 +31,7 @@ import xarray
 from nowcast.workers import grib_to_netcdf
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_grib_to_netcdf.py
+++ b/tests/workers/test_grib_to_netcdf.py
@@ -32,7 +32,7 @@ from nowcast.workers import grib_to_netcdf
 
 
 @pytest.fixture
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | dict:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/workers/test_launch_remote_worker.py
+++ b/tests/workers/test_launch_remote_worker.py
@@ -25,7 +25,7 @@ import pytest
 from nowcast.workers import launch_remote_worker
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     return base_config

--- a/tests/workers/test_launch_remote_worker.py
+++ b/tests/workers/test_launch_remote_worker.py
@@ -122,7 +122,9 @@ class TestLaunchRemoteWorker:
             ("nemo_nowcast.workers.foo", "nemo_nowcast.workers.foo"),
         ),
     )
-    def test_checklist(self, m_next_wkr, m_logger, remote_worker, exp_remote_wkr):
+    def test_checklist(
+        self, m_next_wkr, m_logger, remote_worker, exp_remote_wkr, config
+    ):
         parsed_args = SimpleNamespace(
             host_name="arbutus.cloud",
             remote_worker=remote_worker,

--- a/tests/workers/test_make_201702_runoff_file.py
+++ b/tests/workers/test_make_201702_runoff_file.py
@@ -29,7 +29,7 @@ import pytest
 from nowcast.workers import make_201702_runoff_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_CHS_currents_file.py
+++ b/tests/workers/test_make_CHS_currents_file.py
@@ -29,7 +29,7 @@ import pytest
 from nowcast.workers import make_CHS_currents_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_averaged_dataset.py
+++ b/tests/workers/test_make_averaged_dataset.py
@@ -31,7 +31,7 @@ from nemo_nowcast import WorkerError
 from nowcast.workers import make_averaged_dataset
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_feeds.py
+++ b/tests/workers/test_make_feeds.py
@@ -34,7 +34,7 @@ from nemo_nowcast import WorkerError
 from nowcast.workers import make_feeds
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_forcing_links.py
+++ b/tests/workers/test_make_forcing_links.py
@@ -30,7 +30,7 @@ import pytest
 from nowcast.workers import make_forcing_links
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
@@ -352,7 +352,7 @@ class TestFailure:
         assert msg_type == f"failure {run_type}"
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_clear_links(monkeypatch):
     def mock_clear_links(sftp_client, run_prep_dir, forcing_dir):
         pass

--- a/tests/workers/test_make_live_ocean_files.py
+++ b/tests/workers/test_make_live_ocean_files.py
@@ -29,7 +29,7 @@ import pytest
 from nowcast.workers import make_live_ocean_files
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_plots.py
+++ b/tests/workers/test_make_plots.py
@@ -28,7 +28,7 @@ import pytest
 from nowcast.workers import make_plots
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     return base_config

--- a/tests/workers/test_make_runoff_file.py
+++ b/tests/workers/test_make_runoff_file.py
@@ -34,7 +34,7 @@ from nowcast.workers import make_runoff_file
 
 
 @pytest.fixture
-def config(base_config):
+def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | dict:
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)
     with config_file.open("at") as f:

--- a/tests/workers/test_make_runoff_file.py
+++ b/tests/workers/test_make_runoff_file.py
@@ -33,7 +33,7 @@ import xarray
 from nowcast.workers import make_runoff_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_ssh_file.py
+++ b/tests/workers/test_make_ssh_file.py
@@ -30,7 +30,7 @@ import pytest
 from nowcast.workers import make_ssh_files
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_surface_current_tiles.py
+++ b/tests/workers/test_make_surface_current_tiles.py
@@ -29,7 +29,7 @@ import pytest
 from nowcast.workers import make_surface_current_tiles
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_turbidity_file.py
+++ b/tests/workers/test_make_turbidity_file.py
@@ -27,7 +27,7 @@ import pytest
 from nowcast.workers import make_turbidity_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     return base_config

--- a/tests/workers/test_make_ww3_current_file.py
+++ b/tests/workers/test_make_ww3_current_file.py
@@ -31,7 +31,7 @@ import pytest
 from nowcast.workers import make_ww3_current_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_make_ww3_wind_file.py
+++ b/tests/workers/test_make_ww3_wind_file.py
@@ -31,7 +31,7 @@ import pytest
 from nowcast.workers import make_ww3_wind_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -28,7 +28,7 @@ import pytest
 from nowcast.workers import ping_erddap
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_rotate_hindcast_logs.py
+++ b/tests/workers/test_rotate_hindcast_logs.py
@@ -29,7 +29,7 @@ import pytest
 from nowcast.workers import rotate_hindcast_logs
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config, tmp_path):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_run_NEMO_hindcast.py
+++ b/tests/workers/test_run_NEMO_hindcast.py
@@ -30,7 +30,7 @@ import nowcast.ssh_sftp
 from nowcast.workers import run_NEMO_hindcast
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_run_ww3.py
+++ b/tests/workers/test_run_ww3.py
@@ -33,7 +33,7 @@ import pytest
 from nowcast.workers import run_ww3
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config, tmp_path):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     run_prep_dir = tmp_path / "wwatch3-runs"

--- a/tests/workers/test_update_forecast_datasets.py
+++ b/tests/workers/test_update_forecast_datasets.py
@@ -31,7 +31,7 @@ import pytest
 from nowcast.workers import update_forecast_datasets
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_upload_forcing.py
+++ b/tests/workers/test_upload_forcing.py
@@ -30,7 +30,7 @@ import pytest
 from nowcast.workers import upload_forcing
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)

--- a/tests/workers/test_watch_NEMO_hindcast.py
+++ b/tests/workers/test_watch_NEMO_hindcast.py
@@ -30,7 +30,7 @@ import nowcast.ssh_sftp
 from nowcast.workers import watch_NEMO_hindcast
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(base_config):
     """:py:class:`nemo_nowcast.Config` instance from YAML fragment to use as config for unit tests."""
     config_file = Path(base_config.file)


### PR DESCRIPTION
* Updated `base_config` fixture to use `pytest.tmp_path` because it is preferred over `pytest.tmpdir`. Also add `textwrap.dedent` to fixture for cleaner indentation. Added type annotations to some test module config fixtures to reduce noise from static analysis tools in PyCharm and probably other editors/IDEs.
* Replace deprecated `tmpdir` with `tmp_path` in `prod_config` fixture for better
compatibility and functionality. Updated directory handling to align with
`tmp_path` methods, ensuring consistency and modern practices in test setup.
* Updated the `config` fixture in multiple test files to include type hints for 
input and return types. This reduces noise from static analysis tools in PyCharm 
and probably other editors/IDEs.