### PR TITLE
Refactor `make_runoff_file` workers

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -101,14 +101,14 @@ rivers:
   datamart dir: /SalishSeaCast/datamart/hydrometric/
   # ECCC datamart hydrometric CSV file name template
   # **Must be quoted to protect {} characters**
-  csv file template: 'BC_{stn_id}_hourly_hydrometric.csv'
+  csv file template: "BC_{stn_id}_hourly_hydrometric.csv"
   # USGS waterservice URL
   usgs url: https://waterservices.usgs.gov/nwis/dv/
   # USGS Water Service REST query parameters
   usgs params:
     format: json
     # Parameter code for discharge in cubic ft per second
-    # **Must be quaoted to protect leading zeros**
+    # **Must be quoted to protect leading zeros**
     parameterCd: "00060"
     # River station id and start/end dates that change for every query
     sites: ""
@@ -160,27 +160,27 @@ rivers:
     TheodosiaScotty: /results/forcing/rivers/observations/Theodosia_Scotty_flow
     TheodosiaBypass: /results/forcing/rivers/observations/Theodosia_Bypass_flow
     TheodosiaDiversion: /results/forcing/rivers/observations/Theodosia_Diversion_flow
-  # File that describes Fraser River climatology separation from measured
-  # flow at Hope
-  # **Required for 201702 runoff files used by nowcast-agrif**
-  Fraser climatology: /SalishSeaCast/tools/I_ForcingFiles/Rivers/FraserClimatologySeparation.yaml
+  # Parameters for make_runoff_file workers that vary with the bathymetry version
+  bathy params:
+    # Keyed by bathymetry version
+    v202108:  # SalishSeaCast production bathymetry
+      # Template for the runoff forcing file name
+      file template: "R202108Dailies_{:y%Ym%md%d}.nc"
+      # Module containing dictionary of the proportions that each river occupies in its watershed
+      prop_dict module: salishsea_tools.river_202108
+    v201702:  # **Required for runoff files used by nowcast-agrif**
+      # File that describes Fraser River climatology separation from measured
+      # flow at Hope
+      Fraser climatology: /SalishSeaCast/tools/I_ForcingFiles/Rivers/FraserClimatologySeparation.yaml
+      # Monthly climatology
+      monthly climatology: /SalishSeaCast/rivers-climatology/rivers_month_201702.nc
+      # Template for the runoff forcing file name
+      file template: "R201702DFraCElse_{:y%Ym%md%d}.nc"
+      # Module containing dictionary of the proportions that each river occupies in its watershed
+      prop_dict module: salishsea_tools.river_201702
   # Destination directory for river runoff forcing file
   rivers dir: /results/forcing/rivers/
-  # Monthly climatology
-  # **Required for 201702 runoff files used by nowcast-agrif**
-  monthly climatology:
-    b201702: /SalishSeaCast/rivers-climatology/rivers_month_201702.nc
-  # Templates for the runoff forcing file name
-  # **Must be quoted to project {} characters**
-  file templates:
-    # **201702 runoff files are used by nowcast-agrif**
-    b201702:  "R201702DFraCElse_{:y%Ym%md%d}.nc"
-    b202108:  "R202108Dailies_{:y%Ym%md%d}.nc"
-  # Module containing dictionary of the proportions that each river occupies in its watershed
-  prop_dict modules:
-    # **201702 runoff files are used by nowcast-agrif**
-    b201702: salishsea_tools.river_201702
-    b202108: salishsea_tools.river_202108
+
   turbidity:
     # File containing hourly real-time Fraser River water quality buoy turbidity data
     ECget Fraser turbidity: /results/observations/ECCC/fraser_buoy.csv
@@ -188,7 +188,7 @@ rivers:
     forcing dir: /results/forcing/rivers/river_turb/
     # Template for the turbidity forcing file names
     # **Must be quoted to protect {} characters**
-    file template: 'riverTurbDaily2_{:y%Ym%md%d}.nc'
+    file template: "riverTurbDaily2_{:y%Ym%md%d}.nc"
 
 
 ssh:

--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -393,9 +393,11 @@ def after_make_ssh_files(msg, config, checklist):
         "success forecast2": [],
     }
     if msg.type.startswith("success"):
-        next_workers[msg.type].append(NextWorker("nowcast.workers.make_runoff_file"))
-        next_workers[msg.type].append(
-            NextWorker("nowcast.workers.make_201702_runoff_file")
+        next_workers[msg.type].extend(
+            [
+                NextWorker("nowcast.workers.make_runoff_file", args=["v202108"]),
+                NextWorker("nowcast.workers.make_201702_runoff_file"),
+            ]
         )
     return next_workers[msg.type]
 

--- a/nowcast/workers/make_201702_runoff_file.py
+++ b/nowcast/workers/make_201702_runoff_file.py
@@ -12,6 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """SalishSeaCast runoff file generation worker for v201702 bathymetry.
 
 Blend Environment Canada river gauge data for the Fraser River at Hope with climatology for the
@@ -81,19 +85,21 @@ def make_201702_runoff_file(parsed_args, config, *args):
     otherratio, fraserratio, nonFraser, afterHope = _fraser_climatology(config)
 
     checklist = {}
-    bathy_type = "b201702"
+    bathy_version = "v201702"
     logger.info(f"calculating runoff forcing for b201702 bathymetry")
     # Get climatology
-    climatology_file = Path(config["rivers"]["monthly climatology"][bathy_type])
+    climatology_file = Path(
+        config["rivers"]["bathy params"][bathy_version]["monthly climatology"]
+    )
     criverflow, area = _get_river_climatology(climatology_file)
     # Interpolate to today
     driverflow = _calculate_daily_flow(yesterday, criverflow)
     logger.debug(f'calculated flow for {yesterday.format("YYYY-MM-DD")}')
     # Calculate combined runoff and write file
     directory = Path(config["rivers"]["rivers dir"])
-    filename_tmpls = config["rivers"]["file templates"][bathy_type]
+    filename_tmpls = config["rivers"]["bathy params"][bathy_version]["file template"]
     prop_dict = importlib.import_module(
-        config["rivers"]["prop_dict modules"][bathy_type]
+        config["rivers"]["bathy params"][bathy_version]["prop_dict module"]
     ).prop_dict
     filepath = _combine_runoff(
         prop_dict,
@@ -108,7 +114,7 @@ def make_201702_runoff_file(parsed_args, config, *args):
         directory,
         filename_tmpls,
     )
-    checklist[bathy_type] = os.fspath(filepath)
+    checklist[bathy_version] = os.fspath(filepath)
     return checklist
 
 
@@ -156,7 +162,9 @@ def _calculate_daily_flow(yesterday, criverflow):
 
 def _fraser_climatology(config):
     """Read in the Fraser climatology separated from Hope flow."""
-    fraser_climatology_file = Path(config["rivers"]["Fraser climatology"])
+    fraser_climatology_file = Path(
+        config["rivers"]["bathy params"]["v201702"]["Fraser climatology"]
+    )
     with fraser_climatology_file.open("rt") as f:
         fraser_climatology = yaml.safe_load(f)
     logger.debug(f"read Fraser climatology from {fraser_climatology_file}")

--- a/nowcast/workers/make_forcing_links.py
+++ b/nowcast/workers/make_forcing_links.py
@@ -148,7 +148,8 @@ def _make_runoff_links(sftp_client, run_type, run_date, config, host_name):
     host_config = config["run"]["enabled hosts"][host_name]
     run_prep_dir = Path(host_config["run prep dir"])
     _clear_links(sftp_client, run_prep_dir, "rivers")
-    for tmpl in config["rivers"]["file templates"].values():
+    for bathy_version in config["rivers"]["bathy params"]:
+        tmpl = config["rivers"]["bathy params"][bathy_version]["file template"]
         src = Path(
             host_config["forcing"]["rivers dir"],
             tmpl.format(run_date.shift(days=-1).date()),

--- a/nowcast/workers/make_runoff_file.py
+++ b/nowcast/workers/make_runoff_file.py
@@ -186,6 +186,11 @@ def main():
     """
     worker = NowcastWorker(NAME, description=__doc__)
     worker.init_cli()
+    worker.cli.add_argument(
+        "bathy_version",
+        choices={"v202108"},
+        help="Bathymetry version to make runoff file for.",
+    )
     worker.cli.add_date_option(
         "--data-date",
         default=arrow.now().floor("day").shift(days=-1),
@@ -210,7 +215,7 @@ def failure(parsed_args):
 
 
 def make_runoff_file(parsed_args, config, *args):
-    bathy_version = "v202108"
+    bathy_version = parsed_args.bathy_version
     rivers = importlib.import_module(
         config["rivers"]["bathy params"][bathy_version]["prop_dict module"]
     )

--- a/nowcast/workers/make_runoff_file.py
+++ b/nowcast/workers/make_runoff_file.py
@@ -49,16 +49,16 @@ watersheds = {
     # keys are watershed names
     "bute": {
         # primary and secondary rivers in the watershed
-        "rivers": {"primary": "Homathko_Mouth", "secondary": None},
+        "rivers": {"primary": "HomathkoMouth", "secondary": None},
         # flow factors to scale river flows to total watershed flow
         "flow factors": {"primary": 2.015},
     },
     "evi_n": {
-        "rivers": {"primary": "Salmon_Sayward", "secondary": None},
+        "rivers": {"primary": "SalmonSayward", "secondary": None},
         "flow factors": {"primary": 10.334},
     },
     "jervis": {
-        "rivers": {"primary": "Clowhom_ClowhomLake", "secondary": "RobertsCreek"},
+        "rivers": {"primary": "ClowhomClowhomLake", "secondary": "RobertsCreek"},
         "flow factors": {"primary": 8.810, "secondary": 140.3},
     },
     "evi_s": {
@@ -66,30 +66,30 @@ watersheds = {
         "flow factors": {"primary": 24.60},
     },
     "howe": {
-        "rivers": {"primary": "Squamish_Brackendale", "secondary": None},
+        "rivers": {"primary": "SquamishBrackendale", "secondary": None},
         "flow factors": {"primary": 2.276},
     },
     "jdf": {
-        "rivers": {"primary": "SanJuan_PortRenfrew", "secondary": None},
+        "rivers": {"primary": "SanJuanPortRenfrew", "secondary": None},
         "flow factors": {"primary": 8.501},
     },
     "skagit": {
-        "rivers": {"primary": "Skagit_MountVernon", "secondary": "Snohomish_Monroe"},
+        "rivers": {"primary": "SkagitMountVernon", "secondary": "SnohomishMonroe"},
         "flow factors": {"primary": 1.267, "secondary": 1.236},
     },
     "puget": {
         "rivers": {
-            "primary": "Nisqually_McKenna",
-            "secondary": "Greenwater_Greenwater",
+            "primary": "NisquallyMcKenna",
+            "secondary": "GreenwaterGreenwater",
         },
         "flow factors": {"primary": 8.790, "secondary": 29.09},
     },
     "toba": {
-        "rivers": {"primary": "Homathko_Mouth", "secondary": "Theodosia"},
+        "rivers": {"primary": "HomathkoMouth", "secondary": "Theodosia"},
         "flow factors": {"primary": 0.4563, "secondary": 14.58},
     },
     "fraser": {
-        "rivers": {"primary": "Fraser", "secondary": "Nicomekl_Langley"},
+        "rivers": {"primary": "Fraser", "secondary": "NicomeklLangley"},
         "flow factors": {
             "primary": 1.161,
             "secondary": 162,
@@ -106,7 +106,7 @@ river_patching = {
         # patching strategies to use after the persistence period is over
         "patch strats": ["fit", "persist"],
         # river to use to calculate flow by fitting from
-        "fit from": "Salmon_Sayward",
+        "fit from": "SalmonSayward",
     },
     "Fraser": {
         "persist until": 10_000,  # always persist
@@ -115,7 +115,7 @@ river_patching = {
     "Theodosia": {
         "persist until": 0,
         "patch strats": ["fit", "backup", "persist"],
-        "fit from": "Clowhom_ClowhomLake",
+        "fit from": "ClowhomClowhomLake",
         # backup river to use to calculate flow by fitting from if flow obs from  "fit from" river
         # is not available
         "backup fit from": "Englishman",
@@ -125,56 +125,56 @@ river_patching = {
         "patch strats": ["fit", "persist"],
         "fit from": "Englishman",
     },
-    "Salmon_Sayward": {
+    "SalmonSayward": {
         "persist until": 0,
         "patch strats": ["fit", "persist"],
         "fit from": "Englishman",
     },
-    "Squamish_Brackendale": {
+    "SquamishBrackendale": {
         "persist until": 0,
         "patch strats": ["fit", "persist"],
-        "fit from": "Homathko_Mouth",
+        "fit from": "HomathkoMouth",
     },
-    "SanJuan_PortRenfrew": {
+    "SanJuanPortRenfrew": {
         "persist until": 0,
         "patch strats": ["fit", "backup", "persist"],
         "fit from": "Englishman",
         "backup fit from": "RobertsCreek",
     },
-    "Nisqually_McKenna": {
+    "NisquallyMcKenna": {
         "persist until": 4,
         "patch strats": ["fit", "persist"],
-        "fit from": "Snohomish_Monroe",
+        "fit from": "SnohomishMonroe",
     },
-    "Snohomish_Monroe": {
+    "SnohomishMonroe": {
         "persist until": 0,
         "patch strats": ["fit", "persist"],
-        "fit from": "Skagit_MountVernon",
+        "fit from": "SkagitMountVernon",
     },
-    "Skagit_MountVernon": {
+    "SkagitMountVernon": {
         "persist until": 3,
         "patch strats": ["fit", "persist"],
-        "fit from": "Snohomish_Monroe",
+        "fit from": "SnohomishMonroe",
     },
-    "Homathko_Mouth": {
+    "HomathkoMouth": {
         "persist until": 1,
         "patch strats": ["fit", "persist"],
-        "fit from": "Squamish_Brackendale",
+        "fit from": "SquamishBrackendale",
     },
-    "Nicomekl_Langley": {
+    "NicomeklLangley": {
         "persist until": 0,
         "patch strats": ["fit", "persist"],
         "fit from": "RobertsCreek",
     },
-    "Greenwater_Greenwater": {
+    "GreenwaterGreenwater": {
         "persist until": 1,
         "patch strats": ["fit", "persist"],
-        "fit from": "Snohomish_Monroe",
+        "fit from": "SnohomishMonroe",
     },
-    "Clowhom_ClowhomLake": {
+    "ClowhomClowhomLake": {
         "persist until": 2,
         "patch strats": ["fit", "persist"],
-        "fit from": "Theodosia_Diversion",
+        "fit from": "TheodosiaDiversion",
     },
 }
 
@@ -265,9 +265,9 @@ def _do_fraser(obs_date, config):
     primary_river = _read_river("Fraser", "primary", config)
     primary_flow = _get_river_flow("Fraser", primary_river, obs_date, config)
 
-    secondary_river = _read_river("Nicomekl_Langley", "secondary", config)
+    secondary_river = _read_river("NicomeklLangley", "secondary", config)
     secondary_flow = _get_river_flow(
-        "Nicomekl_Langley", secondary_river, obs_date, config
+        "NicomeklLangley", secondary_river, obs_date, config
     )
 
     fraser_flux = (

--- a/nowcast/workers/upload_forcing.py
+++ b/nowcast/workers/upload_forcing.py
@@ -185,7 +185,8 @@ def _upload_fraser_turbidity_file(
 
 
 def _upload_river_runoff_files(sftp_client, run_date, config, host_name, host_config):
-    for tmpl in config["rivers"]["file templates"].values():
+    for bathy_version in config["rivers"]["bathy params"]:
+        tmpl = config["rivers"]["bathy params"][bathy_version]["file template"]
         filename = tmpl.format(run_date.shift(days=-1).date())
         localpath = Path(config["rivers"]["rivers dir"], filename)
         remotepath = Path(host_config["forcing"]["rivers dir"], filename)

--- a/tests/test_next_workers.py
+++ b/tests/test_next_workers.py
@@ -468,7 +468,7 @@ class TestAfterCollectRiverData:
         assert workers == []
 
 
-class TestAfterMakeV202111RunoffFile:
+class TestAfterMakeRunoffFile:
     """Unit tests for the after_make_runoff_file function."""
 
     @pytest.mark.parametrize("msg_type", ["crash", "failure", "success"])
@@ -562,7 +562,9 @@ class TestAfterMakeSshFiles:
         workers = next_workers.after_make_ssh_files(
             Message("make_ssh_files", msg_type), config, checklist
         )
-        assert workers[0] == NextWorker("nowcast.workers.make_runoff_file")
+        assert workers[0] == NextWorker(
+            "nowcast.workers.make_runoff_file", args=["v202108"]
+        )
 
     @pytest.mark.parametrize("msg_type", ["success nowcast", "success forecast2"])
     def test_success_launch_make_201702_runoff_file(self, msg_type, config, checklist):

--- a/tests/workers/test_make_201702_runoff_file.py
+++ b/tests/workers/test_make_201702_runoff_file.py
@@ -37,17 +37,17 @@ def config(base_config):
         f.write(
             textwrap.dedent(
                 """\
+                SOG river files:
+                  Fraser: SOG-forcing/ECget/Fraser_flow
                 rivers:
+                  bathy params:
+                    v201702:  # **Required for runoff files used by nowcast-agrif**
+                      Fraser climatology: tools/I_ForcingFiles/Rivers/FraserClimatologySeparation.yaml
+                      monthly climatology: rivers-climatology/rivers_month_201702.nc
+                      file template: "R201702DFraCElse_{:y%Ym%md%d}.nc"
+                      prop_dict modules: salishsea_tools.river_201702
                   rivers dir: forcing/rivers/
-                  file templates:
-                    b201702: 'R201702DFraCElse_{:y%Ym%md%d}.nc'
-                  monthly climatology:
-                    b201702: rivers-climatology/rivers_month_201702.nc
-                  prop_dict modules:
-                    b201702: salishsea_tools.river_201702
-                  SOG river files:
-                    Fraser: SOG-forcing/ECget/Fraser_flow
-                  Fraser climatology: tools/I_ForcingFiles/Rivers/FraserClimatologySeparation.yaml
+
                 """
             )
         )
@@ -99,21 +99,28 @@ class TestConfig:
 
     def test_rivers_sections(self, prod_config):
         rivers = prod_config["rivers"]
-        assert rivers["file templates"]["b201702"] == "R201702DFraCElse_{:y%Ym%md%d}.nc"
+        assert (
+            rivers["bathy params"]["v201702"]["file template"]
+            == "R201702DFraCElse_{:y%Ym%md%d}.nc"
+        )
         assert rivers["rivers dir"] == "/results/forcing/rivers/"
-        assert rivers["prop_dict modules"]["b201702"] == "salishsea_tools.river_201702"
+        assert (
+            rivers["bathy params"]["v201702"]["prop_dict module"]
+            == "salishsea_tools.river_201702"
+        )
         assert (
             rivers["SOG river files"]["Capilano"]
             == "/opp/observations/rivers/Capilano/Caplilano_08GA010_day_avg_flow"
         )
 
     def test_rivers_climatology(self, prod_config):
+        climatolgies = prod_config["rivers"]["bathy params"]["v201702"]
         assert (
-            prod_config["rivers"]["Fraser climatology"]
+            climatolgies["Fraser climatology"]
             == "/SalishSeaCast/tools/I_ForcingFiles/Rivers/FraserClimatologySeparation.yaml"
         )
         assert (
-            prod_config["rivers"]["monthly climatology"]["b201702"]
+            climatolgies["monthly climatology"]
             == "/SalishSeaCast/rivers-climatology/rivers_month_201702.nc"
         )
 

--- a/tests/workers/test_make_forcing_links.py
+++ b/tests/workers/test_make_forcing_links.py
@@ -194,7 +194,7 @@ class TestConfig:
 
     def test_rivers_file_templates(self, prod_config):
         assert (
-            prod_config["rivers"]["file templates"]["b201702"]
+            prod_config["rivers"]["bathy params"]["v201702"]["file template"]
             == "R201702DFraCElse_{:y%Ym%md%d}.nc"
         )
 

--- a/tests/workers/test_make_forcing_links.py
+++ b/tests/workers/test_make_forcing_links.py
@@ -41,8 +41,11 @@ def config(base_config):
                 ssh:
                   file template: "ssh_{:y%Ym%md%d}.nc"
                 rivers:
-                  file templates:
-                    b201702: "R201702DFraCElse_{:y%Ym%md%d}.nc"
+                  bathy params:
+                    v202108:  # SalishSeaCast production bathymetry
+                      file template: "R202108Dailies_{:y%Ym%md%d}.nc"
+                    v201702:  # **Required for runoff files used by nowcast-agrif**
+                      file template: "R201702DFraCElse_{:y%Ym%md%d}.nc"
                   turbidity:
                     file template: "riverTurbDaily2_{:y%Ym%md%d}.nc"
 
@@ -450,10 +453,12 @@ class TestMakeRunoffLinks:
         run_prep_dir = tmp_path / host_config["run prep dir"]
         run_prep_dir.mkdir()
         (run_prep_dir / "rivers").mkdir()
-        filename_tmpls = config["rivers"]["file templates"]
+        filename_tmpls = [
+            config["rivers"]["bathy params"][bathy_version]["file template"]
+            for bathy_version in config["rivers"]["bathy params"]
+        ]
         filenames = [
-            tmpl.format(run_date.shift(days=-1).date())
-            for tmpl in filename_tmpls.values()
+            tmpl.format(run_date.shift(days=-1).date()) for tmpl in filename_tmpls
         ]
         for filename in filenames:
             (rivers_dir / filename).write_text("")
@@ -493,9 +498,12 @@ class TestMakeRunoffLinks:
             mock_sftp_client, run_type, run_date, config, host
         )
 
-        filename_tmpls = config["rivers"]["file templates"]
+        filename_tmpls = [
+            config["rivers"]["bathy params"][bathy_version]["file template"]
+            for bathy_version in config["rivers"]["bathy params"]
+        ]
         i = 0
-        for tmpl in filename_tmpls.values():
+        for tmpl in filename_tmpls:
             src_filename = tmpl.format(run_date.shift(days=-1).date())
             for day in range(-1, 3):
                 filename = tmpl.format(run_date.shift(days=day).date())

--- a/tests/workers/test_make_runoff_file.py
+++ b/tests/workers/test_make_runoff_file.py
@@ -176,8 +176,8 @@ class TestModuleVariables:
     make_runoff_file worker.
     """
 
-    def test_watershed_names(self):
-        expected = [
+    def test_watersheds_keys(self):
+        watershed_names = [
             "bute",
             "evi_n",
             "jervis",
@@ -189,126 +189,173 @@ class TestModuleVariables:
             "toba",
             "fraser",
         ]
+        assert list(make_runoff_file.watersheds.keys()) == watershed_names
 
-        assert make_runoff_file.watershed_names == expected
+    @pytest.mark.parametrize(
+        "watershed, rivers",
+        (
+            ("bute", {"primary": "Homathko_Mouth", "secondary": None}),
+            ("evi_n", {"primary": "Salmon_Sayward", "secondary": None}),
+            ("jervis", {"primary": "Clowhom_ClowhomLake", "secondary": "RobertsCreek"}),
+            ("evi_s", {"primary": "Englishman", "secondary": None}),
+            ("howe", {"primary": "Squamish_Brackendale", "secondary": None}),
+            ("jdf", {"primary": "SanJuan_PortRenfrew", "secondary": None}),
+            (
+                "skagit",
+                {
+                    "primary": "Skagit_MountVernon",
+                    "secondary": "Snohomish_Monroe",
+                },
+            ),
+            (
+                "puget",
+                {
+                    "primary": "Nisqually_McKenna",
+                    "secondary": "Greenwater_Greenwater",
+                },
+            ),
+            ("toba", {"primary": "Homathko_Mouth", "secondary": "Theodosia"}),
+            ("fraser", {"primary": "Fraser", "secondary": "Nicomekl_Langley"}),
+        ),
+    )
+    def test_watershed_rivers(self, watershed, rivers):
+        assert make_runoff_file.watersheds[watershed]["rivers"] == rivers
 
-    def test_rivers_for_watershed(self):
-        expected = {
-            "bute": {"primary": "Homathko_Mouth", "secondary": None},
-            "evi_n": {"primary": "Salmon_Sayward", "secondary": None},
-            "jervis": {"primary": "Clowhom_ClowhomLake", "secondary": "RobertsCreek"},
-            "evi_s": {"primary": "Englishman", "secondary": None},
-            "howe": {"primary": "Squamish_Brackendale", "secondary": None},
-            "jdf": {"primary": "SanJuan_PortRenfrew", "secondary": None},
-            "skagit": {
-                "primary": "Skagit_MountVernon",
-                "secondary": "Snohomish_Monroe",
-            },
-            "puget": {
-                "primary": "Nisqually_McKenna",
-                "secondary": "Greenwater_Greenwater",
-            },
-            "toba": {"primary": "Homathko_Mouth", "secondary": "Theodosia"},
-            "fraser": {"primary": "Fraser", "secondary": "Nicomekl_Langley"},
-        }
-
-        assert make_runoff_file.rivers_for_watershed == expected
-
-    def test_watershed_from_river(self):
-        expected = {
-            "bute": {"primary": 2.015},
-            "jervis": {"primary": 8.810, "secondary": 140.3},
-            "howe": {"primary": 2.276},
-            "jdf": {"primary": 8.501},
-            "evi_n": {"primary": 10.334},
-            "evi_s": {"primary": 24.60},
-            "toba": {"primary": 0.4563, "secondary": 14.58},
-            "skagit": {"primary": 1.267, "secondary": 1.236},
-            "puget": {"primary": 8.790, "secondary": 29.09},
-            "fraser": {"primary": 1.161, "secondary": 162, "nico_into_fraser": 0.83565},
-        }
-
-        assert make_runoff_file.watershed_from_river == expected
+    @pytest.mark.parametrize(
+        "watershed, flow_factors",
+        (
+            ("bute", {"primary": 2.015}),
+            ("jervis", {"primary": 8.810, "secondary": 140.3}),
+            ("howe", {"primary": 2.276}),
+            ("jdf", {"primary": 8.501}),
+            ("evi_n", {"primary": 10.334}),
+            ("evi_s", {"primary": 24.60}),
+            ("toba", {"primary": 0.4563, "secondary": 14.58}),
+            ("skagit", {"primary": 1.267, "secondary": 1.236}),
+            ("puget", {"primary": 8.790, "secondary": 29.09}),
+            (
+                "fraser",
+                {"primary": 1.161, "secondary": 162, "nico_into_fraser": 0.83565},
+            ),
+        ),
+    )
+    def test_watershed_flow_factors(self, watershed, flow_factors):
+        assert make_runoff_file.watersheds[watershed]["flow factors"] == flow_factors
 
     def test_theodosia_from_diversion_only(self):
         assert make_runoff_file.theodosia_from_diversion_only == 1.429
 
-    def test_persist_until(self):
-        expected = {
-            # number of days to persist last observation for before switching to fitting strategies
-            "Englishman": 0,
-            "Fraser": 10_000,  # always persist
-            "Theodosia": 0,
-            "RobertsCreek": 0,
-            "Salmon_Sayward": 0,
-            "Squamish_Brackendale": 0,
-            "SanJuan_PortRenfrew": 0,
-            "Nisqually_McKenna": 4,
-            "Snohomish_Monroe": 0,
-            "Skagit_MountVernon": 3,
-            "Homathko_Mouth": 1,
-            "Nicomekl_Langley": 0,
-            "Greenwater_Greenwater": 1,
-            "Clowhom_ClowhomLake": 2,
-        }
+    def test_river_patching_keys(self):
+        river_names = [
+            "Englishman",
+            "Fraser",
+            "Theodosia",
+            "RobertsCreek",
+            "Salmon_Sayward",
+            "Squamish_Brackendale",
+            "SanJuan_PortRenfrew",
+            "Nisqually_McKenna",
+            "Snohomish_Monroe",
+            "Skagit_MountVernon",
+            "Homathko_Mouth",
+            "Nicomekl_Langley",
+            "Greenwater_Greenwater",
+            "Clowhom_ClowhomLake",
+        ]
+        assert list(make_runoff_file.river_patching.keys()) == river_names
 
-        assert make_runoff_file.persist_until == expected
+    @pytest.mark.parametrize(
+        "river, persist_until",
+        (
+            ("Englishman", 0),
+            ("Fraser", 10_000),  # always persist
+            ("Theodosia", 0),
+            ("RobertsCreek", 0),
+            ("Salmon_Sayward", 0),
+            ("Squamish_Brackendale", 0),
+            ("SanJuan_PortRenfrew", 0),
+            ("Nisqually_McKenna", 4),
+            ("Snohomish_Monroe", 0),
+            ("Skagit_MountVernon", 3),
+            ("Homathko_Mouth", 1),
+            ("Nicomekl_Langley", 0),
+            ("Greenwater_Greenwater", 1),
+            ("Clowhom_ClowhomLake", 2),
+        ),
+    )
+    def test_river_patching_persist_until(self, river, persist_until):
+        assert make_runoff_file.river_patching[river]["persist until"] == persist_until
 
-    def test_patching_dictionary(self):
-        expected = {
-            "Englishman": ["fit", "persist"],
-            "Fraser": ["persist"],
-            "Theodosia": ["fit", "backup", "persist"],
-            "RobertsCreek": ["fit", "persist"],
-            "Salmon_Sayward": ["fit", "persist"],
-            "Squamish_Brackendale": ["fit", "persist"],
-            "SanJuan_PortRenfrew": ["fit", "backup", "persist"],
-            "Nisqually_McKenna": ["fit", "persist"],
-            "Snohomish_Monroe": ["fit", "persist"],
-            "Skagit_MountVernon": ["fit", "persist"],
-            "Homathko_Mouth": ["fit", "persist"],
-            "Nicomekl_Langley": ["fit", "persist"],
-            "Greenwater_Greenwater": ["fit", "persist"],
-            "Clowhom_ClowhomLake": ["fit", "persist"],
-        }
+    @pytest.mark.parametrize(
+        "river, patch_strats",
+        (
+            ("Englishman", ["fit", "persist"]),
+            ("Fraser", ["persist"]),
+            ("Theodosia", ["fit", "backup", "persist"]),
+            ("RobertsCreek", ["fit", "persist"]),
+            ("Salmon_Sayward", ["fit", "persist"]),
+            ("Squamish_Brackendale", ["fit", "persist"]),
+            ("SanJuan_PortRenfrew", ["fit", "backup", "persist"]),
+            ("Nisqually_McKenna", ["fit", "persist"]),
+            ("Snohomish_Monroe", ["fit", "persist"]),
+            ("Skagit_MountVernon", ["fit", "persist"]),
+            ("Homathko_Mouth", ["fit", "persist"]),
+            ("Nicomekl_Langley", ["fit", "persist"]),
+            ("Greenwater_Greenwater", ["fit", "persist"]),
+            ("Clowhom_ClowhomLake", ["fit", "persist"]),
+        ),
+    )
+    def test_river_patching_patch_strats(self, river, patch_strats):
+        assert make_runoff_file.river_patching[river]["patch strats"] == patch_strats
 
-        assert make_runoff_file.patching_dictionary == expected
+    def test_patching_strategies(self):
+        """Valid patch strategies are limited to cases handled in _patch_missing_obs()"""
+        valid_patch_strats = ["persist", "fit", "backup"]
 
-    def test_patching_fit_types(self):
-        # Valid fit types are limited to cases handled in _patch_missing_ob()
-        valid_fit_types = ["persist", "fit", "backup"]
+        for river in make_runoff_file.river_patching:
+            for patch_strategy in make_runoff_file.river_patching[river][
+                "patch strats"
+            ]:
+                assert patch_strategy in valid_patch_strats
 
-        for fit_types in make_runoff_file.patching_dictionary.values():
-            for fit_type in fit_types:
-                assert fit_type in valid_fit_types
+    def test_persist_is_last_patching_strategy(self):
+        for river in make_runoff_file.river_patching:
+            assert (
+                make_runoff_file.river_patching[river]["patch strats"][-1] == "persist"
+            )
 
-    def test_persist_is_last_patching_fit_type(self):
-        for fit_types in make_runoff_file.patching_dictionary.values():
-            assert fit_types[-1] == "persist"
+    @pytest.mark.parametrize(
+        "river, fit_from",
+        (
+            ("Englishman", "Salmon_Sayward"),
+            ("Theodosia", "Clowhom_ClowhomLake"),
+            ("RobertsCreek", "Englishman"),
+            ("Salmon_Sayward", "Englishman"),
+            ("Squamish_Brackendale", "Homathko_Mouth"),
+            ("SanJuan_PortRenfrew", "Englishman"),
+            ("Nisqually_McKenna", "Snohomish_Monroe"),
+            ("Snohomish_Monroe", "Skagit_MountVernon"),
+            ("Skagit_MountVernon", "Snohomish_Monroe"),
+            ("Homathko_Mouth", "Squamish_Brackendale"),
+            ("Nicomekl_Langley", "RobertsCreek"),
+            ("Greenwater_Greenwater", "Snohomish_Monroe"),
+            ("Clowhom_ClowhomLake", "Theodosia_Diversion"),
+        ),
+    )
+    def test_river_patching_fit_from(self, river, fit_from):
+        assert make_runoff_file.river_patching[river]["fit from"] == fit_from
 
-    def test_matching_dictionary(self):
-        expected = {
-            "Englishman": "Salmon_Sayward",
-            "Theodosia": "Clowhom_ClowhomLake",
-            "RobertsCreek": "Englishman",
-            "Salmon_Sayward": "Englishman",
-            "Squamish_Brackendale": "Homathko_Mouth",
-            "SanJuan_PortRenfrew": "Englishman",
-            "Nisqually_McKenna": "Snohomish_Monroe",
-            "Snohomish_Monroe": "Skagit_MountVernon",
-            "Skagit_MountVernon": "Snohomish_Monroe",
-            "Homathko_Mouth": "Squamish_Brackendale",
-            "Nicomekl_Langley": "RobertsCreek",
-            "Greenwater_Greenwater": "Snohomish_Monroe",
-            "Clowhom_ClowhomLake": "Theodosia_Diversion",
-        }
-
-        assert make_runoff_file.matching_dictionary == expected
-
-    def test_backup_dictionary(self):
-        expected = {"SanJuan_PortRenfrew": "RobertsCreek", "Theodosia": "Englishman"}
-
-        assert make_runoff_file.backup_dictionary == expected
+    @pytest.mark.parametrize(
+        "river, backup_fit_from",
+        (
+            ("SanJuan_PortRenfrew", "RobertsCreek"),
+            ("Theodosia", "Englishman"),
+        ),
+    )
+    def test_river_patching_backup_fit_from(self, river, backup_fit_from):
+        assert (
+            make_runoff_file.river_patching[river]["backup fit from"] == backup_fit_from
+        )
 
 
 class TestSuccess:
@@ -500,7 +547,7 @@ class TestCalcWatershedFlows:
             "toba": 56.474250732,
             "fraser": 1094.5609129386,
         }
-        for name in make_runoff_file.watershed_names:
+        for name in make_runoff_file.watersheds:
             assert flows[name] == pytest.approx(expected[name])
         assert flows["non_fraser"] == pytest.approx(63.9781423614)
 

--- a/tests/workers/test_make_runoff_file.py
+++ b/tests/workers/test_make_runoff_file.py
@@ -40,7 +40,7 @@ def config(base_config: nemo_nowcast.Config) -> nemo_nowcast.Config | dict:
     with config_file.open("at") as f:
         f.write(
             textwrap.dedent(
-                """\
+                """
                 rivers:
                   SOG river files:
                     HomathkoMouth: forcing/rivers/observations/Homathko_Mouth_flow
@@ -194,28 +194,28 @@ class TestModuleVariables:
     @pytest.mark.parametrize(
         "watershed, rivers",
         (
-            ("bute", {"primary": "Homathko_Mouth", "secondary": None}),
-            ("evi_n", {"primary": "Salmon_Sayward", "secondary": None}),
-            ("jervis", {"primary": "Clowhom_ClowhomLake", "secondary": "RobertsCreek"}),
+            ("bute", {"primary": "HomathkoMouth", "secondary": None}),
+            ("evi_n", {"primary": "SalmonSayward", "secondary": None}),
+            ("jervis", {"primary": "ClowhomClowhomLake", "secondary": "RobertsCreek"}),
             ("evi_s", {"primary": "Englishman", "secondary": None}),
-            ("howe", {"primary": "Squamish_Brackendale", "secondary": None}),
-            ("jdf", {"primary": "SanJuan_PortRenfrew", "secondary": None}),
+            ("howe", {"primary": "SquamishBrackendale", "secondary": None}),
+            ("jdf", {"primary": "SanJuanPortRenfrew", "secondary": None}),
             (
                 "skagit",
                 {
-                    "primary": "Skagit_MountVernon",
-                    "secondary": "Snohomish_Monroe",
+                    "primary": "SkagitMountVernon",
+                    "secondary": "SnohomishMonroe",
                 },
             ),
             (
                 "puget",
                 {
-                    "primary": "Nisqually_McKenna",
-                    "secondary": "Greenwater_Greenwater",
+                    "primary": "NisquallyMcKenna",
+                    "secondary": "GreenwaterGreenwater",
                 },
             ),
-            ("toba", {"primary": "Homathko_Mouth", "secondary": "Theodosia"}),
-            ("fraser", {"primary": "Fraser", "secondary": "Nicomekl_Langley"}),
+            ("toba", {"primary": "HomathkoMouth", "secondary": "Theodosia"}),
+            ("fraser", {"primary": "Fraser", "secondary": "NicomeklLangley"}),
         ),
     )
     def test_watershed_rivers(self, watershed, rivers):
@@ -251,16 +251,16 @@ class TestModuleVariables:
             "Fraser",
             "Theodosia",
             "RobertsCreek",
-            "Salmon_Sayward",
-            "Squamish_Brackendale",
-            "SanJuan_PortRenfrew",
-            "Nisqually_McKenna",
-            "Snohomish_Monroe",
-            "Skagit_MountVernon",
-            "Homathko_Mouth",
-            "Nicomekl_Langley",
-            "Greenwater_Greenwater",
-            "Clowhom_ClowhomLake",
+            "SalmonSayward",
+            "SquamishBrackendale",
+            "SanJuanPortRenfrew",
+            "NisquallyMcKenna",
+            "SnohomishMonroe",
+            "SkagitMountVernon",
+            "HomathkoMouth",
+            "NicomeklLangley",
+            "GreenwaterGreenwater",
+            "ClowhomClowhomLake",
         ]
         assert list(make_runoff_file.river_patching.keys()) == river_names
 
@@ -271,16 +271,16 @@ class TestModuleVariables:
             ("Fraser", 10_000),  # always persist
             ("Theodosia", 0),
             ("RobertsCreek", 0),
-            ("Salmon_Sayward", 0),
-            ("Squamish_Brackendale", 0),
-            ("SanJuan_PortRenfrew", 0),
-            ("Nisqually_McKenna", 4),
-            ("Snohomish_Monroe", 0),
-            ("Skagit_MountVernon", 3),
-            ("Homathko_Mouth", 1),
-            ("Nicomekl_Langley", 0),
-            ("Greenwater_Greenwater", 1),
-            ("Clowhom_ClowhomLake", 2),
+            ("SalmonSayward", 0),
+            ("SquamishBrackendale", 0),
+            ("SanJuanPortRenfrew", 0),
+            ("NisquallyMcKenna", 4),
+            ("SnohomishMonroe", 0),
+            ("SkagitMountVernon", 3),
+            ("HomathkoMouth", 1),
+            ("NicomeklLangley", 0),
+            ("GreenwaterGreenwater", 1),
+            ("ClowhomClowhomLake", 2),
         ),
     )
     def test_river_patching_persist_until(self, river, persist_until):
@@ -293,16 +293,16 @@ class TestModuleVariables:
             ("Fraser", ["persist"]),
             ("Theodosia", ["fit", "backup", "persist"]),
             ("RobertsCreek", ["fit", "persist"]),
-            ("Salmon_Sayward", ["fit", "persist"]),
-            ("Squamish_Brackendale", ["fit", "persist"]),
-            ("SanJuan_PortRenfrew", ["fit", "backup", "persist"]),
-            ("Nisqually_McKenna", ["fit", "persist"]),
-            ("Snohomish_Monroe", ["fit", "persist"]),
-            ("Skagit_MountVernon", ["fit", "persist"]),
-            ("Homathko_Mouth", ["fit", "persist"]),
-            ("Nicomekl_Langley", ["fit", "persist"]),
-            ("Greenwater_Greenwater", ["fit", "persist"]),
-            ("Clowhom_ClowhomLake", ["fit", "persist"]),
+            ("SalmonSayward", ["fit", "persist"]),
+            ("SquamishBrackendale", ["fit", "persist"]),
+            ("SanJuanPortRenfrew", ["fit", "backup", "persist"]),
+            ("NisquallyMcKenna", ["fit", "persist"]),
+            ("SnohomishMonroe", ["fit", "persist"]),
+            ("SkagitMountVernon", ["fit", "persist"]),
+            ("HomathkoMouth", ["fit", "persist"]),
+            ("NicomeklLangley", ["fit", "persist"]),
+            ("GreenwaterGreenwater", ["fit", "persist"]),
+            ("ClowhomClowhomLake", ["fit", "persist"]),
         ),
     )
     def test_river_patching_patch_strats(self, river, patch_strats):
@@ -327,19 +327,19 @@ class TestModuleVariables:
     @pytest.mark.parametrize(
         "river, fit_from",
         (
-            ("Englishman", "Salmon_Sayward"),
-            ("Theodosia", "Clowhom_ClowhomLake"),
+            ("Englishman", "SalmonSayward"),
+            ("Theodosia", "ClowhomClowhomLake"),
             ("RobertsCreek", "Englishman"),
-            ("Salmon_Sayward", "Englishman"),
-            ("Squamish_Brackendale", "Homathko_Mouth"),
-            ("SanJuan_PortRenfrew", "Englishman"),
-            ("Nisqually_McKenna", "Snohomish_Monroe"),
-            ("Snohomish_Monroe", "Skagit_MountVernon"),
-            ("Skagit_MountVernon", "Snohomish_Monroe"),
-            ("Homathko_Mouth", "Squamish_Brackendale"),
-            ("Nicomekl_Langley", "RobertsCreek"),
-            ("Greenwater_Greenwater", "Snohomish_Monroe"),
-            ("Clowhom_ClowhomLake", "Theodosia_Diversion"),
+            ("SalmonSayward", "Englishman"),
+            ("SquamishBrackendale", "HomathkoMouth"),
+            ("SanJuanPortRenfrew", "Englishman"),
+            ("NisquallyMcKenna", "SnohomishMonroe"),
+            ("SnohomishMonroe", "SkagitMountVernon"),
+            ("SkagitMountVernon", "SnohomishMonroe"),
+            ("HomathkoMouth", "SquamishBrackendale"),
+            ("NicomeklLangley", "RobertsCreek"),
+            ("GreenwaterGreenwater", "SnohomishMonroe"),
+            ("ClowhomClowhomLake", "TheodosiaDiversion"),
         ),
     )
     def test_river_patching_fit_from(self, river, fit_from):
@@ -348,7 +348,7 @@ class TestModuleVariables:
     @pytest.mark.parametrize(
         "river, backup_fit_from",
         (
-            ("SanJuan_PortRenfrew", "RobertsCreek"),
+            ("SanJuanPortRenfrew", "RobertsCreek"),
             ("Theodosia", "Englishman"),
         ),
     )
@@ -597,7 +597,7 @@ class TestDoFraser:
             ),
             # Secondary river
             pandas.DataFrame(
-                # Nicomekl_Langley
+                # NicomeklLangley
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-19"),
@@ -639,7 +639,7 @@ class TestDoFraser:
             ),
             # Secondary river
             pandas.DataFrame(
-                # Nicomekl_Langley
+                # NicomeklLangley
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-19"),
@@ -660,7 +660,7 @@ class TestDoFraser:
         mock_river_flows = [
             # Fraser
             6.528406e02,
-            # Nicomekl_Langley
+            # NicomeklLangley
             2.402962e00,
         ]
 
@@ -693,7 +693,7 @@ class TestDoFraser:
             ),
             # Secondary river
             pandas.DataFrame(
-                # Nicomekl_Langley
+                # NicomeklLangley
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-18"),
@@ -713,7 +713,7 @@ class TestDoFraser:
         mock_river_flows = [
             # Fraser
             6.625833e02,
-            # Nicomekl_Langley
+            # NicomeklLangley
             2.402962e00,
         ]
 
@@ -736,7 +736,7 @@ class TestDoARiverPair:
     def test_primary_river_only_no_patch_required(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config_):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-13"),
@@ -752,7 +752,7 @@ class TestDoARiverPair:
 
         watershed_name = "bute"
         obs_date = arrow.get("2023-02-13")
-        primary_river_name = "Homathko_Mouth"
+        primary_river_name = "HomathkoMouth"
         secondary_river_name = None
 
         watershed_flux = make_runoff_file._do_a_river_pair(
@@ -764,7 +764,7 @@ class TestDoARiverPair:
     def test_primary_river_patched(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config_):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-17"),
@@ -788,7 +788,7 @@ class TestDoARiverPair:
 
         watershed_name = "bute"
         obs_date = arrow.get("2023-02-18")
-        primary_river_name = "Homathko_Mouth"
+        primary_river_name = "HomathkoMouth"
         secondary_river_name = None
 
         watershed_flux = make_runoff_file._do_a_river_pair(
@@ -801,7 +801,7 @@ class TestDoARiverPair:
         mock_dataframes = [
             # Primary river
             pandas.DataFrame(
-                # Clowhom_ClowhomLake
+                # ClowhomClowhomLake
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-13"),
@@ -834,7 +834,7 @@ class TestDoARiverPair:
 
         watershed_name = "jervis"
         obs_date = arrow.get("2023-02-13")
-        primary_river_name = "Clowhom_ClowhomLake"
+        primary_river_name = "ClowhomClowhomLake"
         secondary_river_name = "RobertsCreek"
 
         watershed_flux = make_runoff_file._do_a_river_pair(
@@ -846,7 +846,7 @@ class TestDoARiverPair:
     def test_secondary_Theodosia_no_patches(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config_):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-18"),
@@ -880,7 +880,7 @@ class TestDoARiverPair:
 
         watershed_name = "toba"
         obs_date = arrow.get("2023-02-18")
-        primary_river_name = "Homathko_Mouth"
+        primary_river_name = "HomathkoMouth"
         secondary_river_name = "Theodosia"
 
         watershed_flux = make_runoff_file._do_a_river_pair(
@@ -893,7 +893,7 @@ class TestDoARiverPair:
         mock_dataframes = [
             # Primary river
             pandas.DataFrame(
-                # Clowhom_ClowhomLake
+                # ClowhomClowhomLake
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-18"),
@@ -934,7 +934,7 @@ class TestDoARiverPair:
 
         watershed_name = "jervis"
         obs_date = arrow.get("2023-02-13")
-        primary_river_name = "Clowhom_ClowhomLake"
+        primary_river_name = "ClowhomClowhomLake"
         secondary_river_name = "RobertsCreek"
 
         watershed_flux = make_runoff_file._do_a_river_pair(
@@ -951,7 +951,7 @@ class TestGetRiverFlow:
     """Unit tests for _get_river_flow()."""
 
     def test_get_river_flow(self, flow_col_label, config):
-        river_name = "SanJuan_PortRenfrew"
+        river_name = "SanJuanPortRenfrew"
         river_df = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -986,7 +986,7 @@ class TestGetRiverFlow:
             make_runoff_file, "_patch_missing_obs", mock_patch_missing_obs
         )
 
-        river_name = "SanJuan_PortRenfrew"
+        river_name = "SanJuanPortRenfrew"
         river_df = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -1014,7 +1014,7 @@ class TestGetRiverFlow:
         assert caplog.records[0].levelname == "ERROR"
         assert (
             caplog.messages[0]
-            == "no 2023-02-16 discharge obs for SanJuan_PortRenfrew: patching"
+            == "no 2023-02-16 discharge obs for SanJuanPortRenfrew: patching"
         )
 
         assert river_flow == pytest.approx(4.749479e01)
@@ -1043,7 +1043,7 @@ class TestReadRiver:
 
         monkeypatch.setattr(make_runoff_file, "_read_river_csv", mock_read_river_csv)
 
-        river_name = "Squamish_Brackendale"
+        river_name = "SquamishBrackendale"
 
         river_flow = make_runoff_file._read_river(river_name, ps, config)
 
@@ -1216,7 +1216,7 @@ class TestPatchMissingObs:
     """Unit tests for make_runoff_file._patch_missing_obs()."""
 
     def test_obs_date_not_at_end_of_timeseries(self, config, caplog):
-        river_name = "Nicomekl_Langley"
+        river_name = "NicomeklLangley"
         river_flow = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -1252,7 +1252,7 @@ class TestPatchMissingObs:
             )
 
     def test_persist(self, config, caplog):
-        river_name = "Clowhom_ClowhomLake"
+        river_name = "ClowhomClowhomLake"
         river_flow = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -1279,7 +1279,7 @@ class TestPatchMissingObs:
 
         assert caplog.records[0].levelname == "DEBUG"
         expected = (
-            "patched missing 2023-02-16 Clowhom_ClowhomLake discharge by persistence"
+            "patched missing 2023-02-16 ClowhomClowhomLake discharge by persistence"
         )
         assert caplog.messages[0] == expected
 
@@ -1294,7 +1294,7 @@ class TestPatchMissingObs:
 
         monkeypatch.setattr(make_runoff_file, "_patch_fitting", mock_patch_fitting)
 
-        river_name = "Squamish_Brackendale"
+        river_name = "SquamishBrackendale"
         river_flow = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -1330,7 +1330,7 @@ class TestPatchMissingObs:
         )
 
         assert caplog.records[0].levelname == "DEBUG"
-        expected = "patched missing 2023-02-14 Squamish_Brackendale discharge by fitting from Homathko_Mouth"
+        expected = "patched missing 2023-02-14 SquamishBrackendale discharge by fitting from HomathkoMouth"
         assert caplog.messages[0] == expected
 
         assert flux == pytest.approx(54.759385)
@@ -1349,7 +1349,7 @@ class TestPatchMissingObs:
 
         monkeypatch.setattr(make_runoff_file, "_patch_fitting", mock_patch_fitting)
 
-        river_name = "SanJuan_PortRenfrew"
+        river_name = "SanJuanPortRenfrew"
         river_flow = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -1375,7 +1375,7 @@ class TestPatchMissingObs:
         )
 
         assert caplog.records[0].levelname == "DEBUG"
-        expected = "patched missing 2023-02-16 SanJuan_PortRenfrew discharge by fitting from backup river: RobertsCreek"
+        expected = "patched missing 2023-02-16 SanJuanPortRenfrew discharge by fitting from backup river: RobertsCreek"
         assert caplog.messages[0] == expected
 
         assert flux == pytest.approx(68.43567)
@@ -1394,7 +1394,7 @@ class TestPatchMissingObs:
 
         monkeypatch.setattr(make_runoff_file, "_patch_fitting", mock_patch_fitting)
 
-        river_name = "SanJuan_PortRenfrew"
+        river_name = "SanJuanPortRenfrew"
         river_flow = pandas.DataFrame(
             index=pandas.Index(
                 data=[
@@ -1421,7 +1421,7 @@ class TestPatchMissingObs:
 
         assert caplog.records[0].levelname == "DEBUG"
         expected = (
-            "patched missing 2023-02-16 SanJuan_PortRenfrew discharge by persistence"
+            "patched missing 2023-02-16 SanJuanPortRenfrew discharge by persistence"
         )
         assert caplog.messages[0] == expected
 
@@ -1434,7 +1434,7 @@ class TestPatchFitting:
     def test_1_day_missing_patch_successful(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-06"),
@@ -1467,7 +1467,7 @@ class TestPatchFitting:
         monkeypatch.setattr(make_runoff_file, "_read_river", mock_read_river)
 
         river_flow = pandas.DataFrame(
-            # Squamish_Brackendale
+            # SquamishBrackendale
             index=pandas.Index(
                 data=[
                     pandas.to_datetime("2023-02-06"),
@@ -1494,7 +1494,7 @@ class TestPatchFitting:
                 ],
             },
         )
-        fit_from_river_name = "Homathko_Mouth"
+        fit_from_river_name = "HomathkoMouth"
         obs_date = arrow.get("2023-02-14")
         gap_length = 1
 
@@ -1507,7 +1507,7 @@ class TestPatchFitting:
     def test_3_days_missing_patch_successful(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-04"),
@@ -1544,7 +1544,7 @@ class TestPatchFitting:
         monkeypatch.setattr(make_runoff_file, "_read_river", mock_read_river)
 
         river_flow = pandas.DataFrame(
-            # Squamish_Brackendale
+            # SquamishBrackendale
             index=pandas.Index(
                 data=[
                     pandas.to_datetime("2023-02-04"),
@@ -1571,7 +1571,7 @@ class TestPatchFitting:
                 ],
             },
         )
-        fit_from_river_name = "Homathko_Mouth"
+        fit_from_river_name = "HomathkoMouth"
         obs_date = arrow.get("2023-02-14")
         gap_length = 3
 
@@ -1584,7 +1584,7 @@ class TestPatchFitting:
     def test_gap_in_river_to_patch_failure(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-06"),
@@ -1617,7 +1617,7 @@ class TestPatchFitting:
         monkeypatch.setattr(make_runoff_file, "_read_river", mock_read_river)
 
         river_flow = pandas.DataFrame(
-            # Squamish_Brackendale
+            # SquamishBrackendale
             index=pandas.Index(
                 data=[
                     pandas.to_datetime("2023-02-06"),
@@ -1644,7 +1644,7 @@ class TestPatchFitting:
                 ],
             },
         )
-        fit_from_river_name = "Homathko_Mouth"
+        fit_from_river_name = "HomathkoMouth"
         obs_date = arrow.get("2023-02-14")
         gap_length = 1
 
@@ -1657,7 +1657,7 @@ class TestPatchFitting:
     def test_gap_in_river_to_fit_from_failure(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-06"),
@@ -1690,7 +1690,7 @@ class TestPatchFitting:
         monkeypatch.setattr(make_runoff_file, "_read_river", mock_read_river)
 
         river_flow = pandas.DataFrame(
-            # Squamish_Brackendale
+            # SquamishBrackendale
             index=pandas.Index(
                 data=[
                     pandas.to_datetime("2023-02-06"),
@@ -1717,7 +1717,7 @@ class TestPatchFitting:
                 ],
             },
         )
-        fit_from_river_name = "Homathko_Mouth"
+        fit_from_river_name = "HomathkoMouth"
         obs_date = arrow.get("2023-02-14")
         gap_length = 1
 
@@ -1730,7 +1730,7 @@ class TestPatchFitting:
     def test_river_to_patch_from_missing_obs_date_failure(self, config, monkeypatch):
         def mock_read_river(river_name, ps, config):
             return pandas.DataFrame(
-                # Homathko_Mouth
+                # HomathkoMouth
                 index=pandas.Index(
                     data=[
                         pandas.to_datetime("2023-02-06"),
@@ -1763,7 +1763,7 @@ class TestPatchFitting:
         monkeypatch.setattr(make_runoff_file, "_read_river", mock_read_river)
 
         river_flow = pandas.DataFrame(
-            # Squamish_Brackendale
+            # SquamishBrackendale
             index=pandas.Index(
                 data=[
                     pandas.to_datetime("2023-02-06"),
@@ -1790,7 +1790,7 @@ class TestPatchFitting:
                 ],
             },
         )
-        fit_from_river_name = "Homathko_Mouth"
+        fit_from_river_name = "HomathkoMouth"
         obs_date = arrow.get("2023-02-14")
         gap_length = 1
 

--- a/tests/workers/test_make_runoff_file.py
+++ b/tests/workers/test_make_runoff_file.py
@@ -87,15 +87,22 @@ class TestMain:
             "SalishSeaCast worker that calculates NEMO runoff forcing file."
         )
 
+    def test_add_bathy_version_arg(self, mock_worker):
+        worker = make_runoff_file.main()
+
+        assert worker.cli.parser._actions[3].dest == "bathy_version"
+        assert worker.cli.parser._actions[3].choices == {"v202108"}
+        assert worker.cli.parser._actions[3].help
+
     def test_add_data_date_option(self, mock_worker):
         worker = make_runoff_file.main()
 
-        assert worker.cli.parser._actions[3].dest == "data_date"
+        assert worker.cli.parser._actions[4].dest == "data_date"
         expected = nemo_nowcast.cli.CommandLineInterface.arrow_date
-        assert worker.cli.parser._actions[3].type == expected
+        assert worker.cli.parser._actions[4].type == expected
         expected = arrow.now().floor("day").shift(days=-1)
-        assert worker.cli.parser._actions[3].default == expected
-        assert worker.cli.parser._actions[3].help
+        assert worker.cli.parser._actions[4].default == expected
+        assert worker.cli.parser._actions[4].help
 
 
 class TestConfig:
@@ -454,7 +461,9 @@ class TestMakeRunoffFile:
         tmp_rivers_dir.mkdir(parents=True)
         monkeypatch.setitem(config["rivers"], "rivers dir", tmp_rivers_dir)
 
-        parsed_args = SimpleNamespace(data_date=arrow.get("2023-05-19"))
+        parsed_args = SimpleNamespace(
+            bathy_version="v202108", data_date=arrow.get("2023-05-19")
+        )
 
         checklist = make_runoff_file.make_runoff_file(parsed_args, config)
 
@@ -478,7 +487,9 @@ class TestMakeRunoffFile:
         tmp_rivers_dir.mkdir(parents=True)
         monkeypatch.setitem(config["rivers"], "rivers dir", tmp_rivers_dir)
 
-        parsed_args = SimpleNamespace(data_date=arrow.get("2023-05-26"))
+        parsed_args = SimpleNamespace(
+            bathy_version="v202108", data_date=arrow.get("2023-05-26")
+        )
         caplog.set_level(logging.DEBUG)
 
         make_runoff_file.make_runoff_file(parsed_args, config)


### PR DESCRIPTION
* Replaced flat module-level variables in `make_runoff_file` with nested dictionaries for better organization and maintainability. Updated related test cases and functions to use the new data structures, simplifying access and improving readability.

* Updated river names in `make_runoff_file` code and tests files from snake_case 
to CamelCase for consistency with the naming convention used in the `nowcast
.yaml` configuration file.

* Reorganized river runoff file configurations by introducing `bathy params`
keyed by bathymetry versions (e.g., v202108, v201702). Updated corresponding
workers, tests, and YAML configurations to support this structure.

* Introduced a `bathy_version` argument to the `make_runoff_file` worker for
selecting bathymetry versions. Updated tests and next workers logic to handle and
validate this new argument.