### PR TITLE
Fix `run_date` scope in after_update_forecast_datasets()

### DIFF
--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1560,13 +1560,12 @@ def after_update_forecast_datasets(msg, config, checklist):
         "success wwatch3 forecast2": [],
     }
     if msg.type.startswith("success"):
-        model = msg.type.split()[1]
-        run_type = msg.type.split()[2]
-        run_date = checklist[f"{model.upper()} run"][run_type]["run date"]
+        _, model, run_type = msg.type.split()
         next_workers[msg.type].append(
             NextWorker("nowcast.workers.ping_erddap", args=[f"{model}-forecast"])
         )
         if model == "nemo":
+            run_date = checklist[f"{model.upper()} run"][run_type]["run date"]
             next_workers[msg.type].extend(
                 [
                     NextWorker(


### PR DESCRIPTION
Moved the `run_date` assignment inside the NEMO-specific condition to avoid automation manager crashes due to missing "WWATCH3 run" item in checklist. The situation occurred occasionally when the checklist was cleared while the `download_wwatch3_results` worker was still running. This change prevents the issue when processing non-NEMO models.