### PR TITLE
Update collect_river_data checklist structure re: issue #170

### DIFF
--- a/nowcast/workers/collect_river_data.py
+++ b/nowcast/workers/collect_river_data.py
@@ -21,6 +21,7 @@ an ECCC datamart CSV file mirror, or the USGS Water Service REST service,
 and appends a day-average discharge to a SOG-format forcing file.
 """
 import logging
+import os
 from pathlib import Path
 
 import arrow
@@ -107,7 +108,10 @@ def collect_river_data(parsed_args, config, *args):
     day_avg_discharge = day_avg_discharge_funcs[data_src](river_name, data_date, config)
     daily_avg_file = Path(config["rivers"]["SOG river files"][river_name])
     _store_day_avg_discharge(data_date, day_avg_discharge, daily_avg_file)
-    checklist = {"river name": river_name, "data date": data_date.format("YYYY-MM-DD")}
+    checklist = {
+        river_name: os.fspath(daily_avg_file),
+        "data date": data_date.format("YYYY-MM-DD"),
+    }
     logger.info(
         f"Appended {data_src} {river_name} river average discharge for "
         f"{data_date.format('YYYY-MM-DD')} to: {daily_avg_file}"

--- a/nowcast/workers/collect_river_data.py
+++ b/nowcast/workers/collect_river_data.py
@@ -12,6 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
 """SalishSeaCast worker that collects river discharge observation data from
 an ECCC datamart CSV file mirror, or the USGS Water Service REST service,
 and appends a day-average discharge to a SOG-format forcing file.

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -286,6 +286,31 @@ class TestCollectRiverData:
 
         checklist = collect_river_data.collect_river_data(parsed_args, config)
 
+        expected = {"river name": river_name, "data date": "2018-12-26"}
+        assert checklist == expected
+
+    def test_log_messages(
+        self,
+        mock_calc_eccc_day_avg_discharge,
+        mock_get_usgs_day_avg_discharge,
+        data_src,
+        river_name,
+        config,
+        caplog,
+        tmp_path,
+        monkeypatch,
+    ):
+        sog_river_file = config["rivers"]["SOG river files"][river_name]
+        monkeypatch.setitem(
+            config["rivers"]["SOG river files"], river_name, tmp_path / sog_river_file
+        )
+        parsed_args = SimpleNamespace(
+            data_src=data_src, river_name=river_name, data_date=arrow.get("2018-12-26")
+        )
+        caplog.set_level(logging.DEBUG)
+
+        collect_river_data.collect_river_data(parsed_args, config)
+
         assert caplog.records[0].levelname == "INFO"
         expected = f"Collecting {data_src} {river_name} river data for 2018-12-26"
         assert caplog.messages[0] == expected
@@ -295,8 +320,6 @@ class TestCollectRiverData:
             f"{Path(config['rivers']['SOG river files'][river_name])}"
         )
         assert caplog.messages[2] == expected
-        expected = {"river name": river_name, "data date": "2018-12-26"}
-        assert checklist == expected
 
 
 class TestCalcECCC_DayAvgDischarge:

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -18,6 +18,7 @@
 
 """Unit tests for SalishSeaCast collect_river_data worker."""
 import logging
+import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -286,7 +287,10 @@ class TestCollectRiverData:
 
         checklist = collect_river_data.collect_river_data(parsed_args, config)
 
-        expected = {"river name": river_name, "data date": "2018-12-26"}
+        expected = {
+            river_name: os.fspath(tmp_path / sog_river_file),
+            "data date": "2018-12-26",
+        }
         assert checklist == expected
 
     def test_log_messages(

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -240,36 +240,48 @@ class TestFailure:
 class TestCollectRiverData:
     """Unit test for collect_river_data() function."""
 
-    def test_checklist(
-        self, data_src, river_name, config, caplog, tmp_path, monkeypatch
-    ):
-        def mock_calc_eccc_day_avg_discharge(river_name, data_date, config):
+    @staticmethod
+    @pytest.fixture
+    def mock_calc_eccc_day_avg_discharge(monkeypatch):
+        def _mock_calc_eccc_day_avg_discharge(river_name, data_date, config):
             return 12345.6
 
         monkeypatch.setattr(
             collect_river_data,
             "_calc_eccc_day_avg_discharge",
-            mock_calc_eccc_day_avg_discharge,
+            _mock_calc_eccc_day_avg_discharge,
         )
 
-        def mock_get_usgs_day_avg_discharge(river_name, data_date, config):
+    @staticmethod
+    @pytest.fixture
+    def mock_get_usgs_day_avg_discharge(monkeypatch):
+        def _mock_get_usgs_day_avg_discharge(river_name, data_date, config):
             return 12345.6
 
         monkeypatch.setattr(
             collect_river_data,
             "_get_usgs_day_avg_discharge",
-            mock_get_usgs_day_avg_discharge,
+            _mock_get_usgs_day_avg_discharge,
         )
 
+    def test_checklist(
+        self,
+        mock_calc_eccc_day_avg_discharge,
+        mock_get_usgs_day_avg_discharge,
+        data_src,
+        river_name,
+        config,
+        caplog,
+        tmp_path,
+        monkeypatch,
+    ):
         sog_river_file = config["rivers"]["SOG river files"][river_name]
         monkeypatch.setitem(
             config["rivers"]["SOG river files"], river_name, tmp_path / sog_river_file
         )
-
         parsed_args = SimpleNamespace(
             data_src=data_src, river_name=river_name, data_date=arrow.get("2018-12-26")
         )
-
         caplog.set_level(logging.DEBUG)
 
         checklist = collect_river_data.collect_river_data(parsed_args, config)

--- a/tests/workers/test_collect_river_data.py
+++ b/tests/workers/test_collect_river_data.py
@@ -77,6 +77,7 @@ class TestMain:
 
     def test_instantiate_worker(self, mock_worker):
         worker = collect_river_data.main()
+
         assert worker.name == "collect_river_data"
         assert worker.description.startswith(
             "SalishSeaCast worker that collects river discharge observation data"
@@ -84,18 +85,21 @@ class TestMain:
 
     def test_add_data_source_arg(self, mock_worker):
         worker = collect_river_data.main()
+
         assert worker.cli.parser._actions[3].dest == "data_src"
         assert worker.cli.parser._actions[3].choices == {"ECCC", "USGS"}
         assert worker.cli.parser._actions[3].help
 
     def test_add_river_name_arg(self, mock_worker):
         worker = collect_river_data.main()
+
         assert worker.cli.parser._actions[4].dest == "river_name"
         assert worker.cli.parser._actions[4].default is None
         assert worker.cli.parser._actions[4].help
 
     def test_add_data_date_option(self, mock_worker):
         worker = collect_river_data.main()
+
         assert worker.cli.parser._actions[5].dest == "data_date"
         expected = nemo_nowcast.cli.CommandLineInterface.arrow_date
         assert worker.cli.parser._actions[5].type == expected
@@ -197,7 +201,9 @@ class TestSuccess:
             data_src="ECCC", river_name="Fraser", data_date=arrow.get("2018-12-26")
         )
         caplog.set_level(logging.INFO)
+
         msg_type = collect_river_data.success(parsed_args)
+
         assert caplog.records[0].levelname == "INFO"
         expected = "ECCC Fraser river data collection for 2018-12-26 completed"
         assert caplog.messages[0] == expected
@@ -212,7 +218,9 @@ class TestFailure:
             data_src="ECCC", river_name="Fraser", data_date=arrow.get("2018-12-26")
         )
         caplog.set_level(logging.CRITICAL)
+
         msg_type = collect_river_data.failure(parsed_args)
+
         assert caplog.records[0].levelname == "CRITICAL"
         expected = (
             "Calculation of ECCC Fraser river average discharge for 2018-12-26 or "


### PR DESCRIPTION
Modified the checklist to replace "river name" item with the river name from the
config and the day-averaged flow file path using `os.fspath`. This addresses
issue #170 by making the river name key in the checklist unique for every river.
That ensures that the river names and the files in which their data were
collected all appear in the checklist instead of just the last river that was
processed.