### PR TITLE
Add backfill support to download_weather worker

### DIFF
--- a/nowcast/workers/download_weather.py
+++ b/nowcast/workers/download_weather.py
@@ -104,7 +104,8 @@ def get_grib(parsed_args, config, *args):
     grp_name = config["file group"]
     _mkdirs(dest_dir_root, date, forecast, grp_name, parsed_args.backfill)
     logger.debug(
-        f"destination directory for {forecast} {resolution} forecast GRIB2 files: {dest_dir_root}"
+        f"destination directory for {forecast} {resolution} forecast GRIB2 files: "
+        f"{dest_dir_root}{date}/{forecast}"
     )
     url_tmpl = config["weather"]["download"][resolution]["url template"]
     filename_tmpl = config["weather"]["download"][resolution]["ECCC file template"]

--- a/nowcast/workers/download_weather.py
+++ b/nowcast/workers/download_weather.py
@@ -121,7 +121,7 @@ def get_grib(parsed_args, config, *args):
         for forecast_hour in range(1, forecast_duration + 1):
             hr_str = f"{forecast_hour:0=3}"
             lib.mkdir(
-                os.path.join(dest_dir_root, date, forecast, hr_str),
+                Path(dest_dir_root, date, forecast, hr_str),
                 logger,
                 grp_name=grp_name,
                 exist_ok=False,
@@ -147,9 +147,9 @@ def get_grib(parsed_args, config, *args):
 
 
 def _mkdirs(dest_dir_root, date, forecast, grp_name, exist_ok):
-    lib.mkdir(os.path.join(dest_dir_root, date), logger, grp_name=grp_name)
+    lib.mkdir(Path(dest_dir_root, date), logger, grp_name=grp_name)
     lib.mkdir(
-        os.path.join(dest_dir_root, date, forecast),
+        Path(dest_dir_root, date, forecast),
         logger,
         grp_name=grp_name,
         exist_ok=exist_ok,
@@ -162,13 +162,11 @@ def _get_file(
     filename = filename_tmpl.format(
         variable=var, date=date, forecast=forecast, hour=hr_str
     )
-    filepath = os.path.join(dest_dir_root, date, forecast, hr_str, filename)
+    filepath = Path(dest_dir_root, date, forecast, hr_str, filename)
     file_url = url_tmpl.format(
         date=date, forecast=forecast, hour=hr_str, filename=filename
     )
-    get_web_data(
-        file_url, NAME, Path(filepath), session=session, wait_exponential_max=9000
-    )
+    get_web_data(file_url, NAME, filepath, session=session, wait_exponential_max=9000)
     size = os.stat(filepath).st_size
     logger.debug(f"downloaded {size} bytes from {file_url}")
     if size == 0:

--- a/tests/workers/test_download_weather.py
+++ b/tests/workers/test_download_weather.py
@@ -290,10 +290,17 @@ class TestFailure:
 
 
 @patch("nowcast.workers.download_weather.lib.mkdir", autospec=True)
-@patch("nowcast.workers.download_weather.lib.fix_perms", autospec=True)
 @patch("nowcast.workers.download_weather._get_file", autospec=True)
 class TestGetGrib:
     """Unit tests for get_grib() function."""
+
+    @staticmethod
+    @pytest.fixture
+    def mock_fix_perms(monkeypatch):
+        def _mock_fix_perms(filepath):
+            pass
+
+        monkeypatch.setattr(download_weather.lib, "fix_perms", _mock_fix_perms)
 
     @pytest.mark.parametrize(
         "forecast, resolution",
@@ -307,8 +314,8 @@ class TestGetGrib:
     def test_make_hour_dirs_2_5km(
         self,
         m_get_file,
-        m_fix_perms,
         m_mkdir,
+        mock_fix_perms,
         forecast,
         resolution,
         config,
@@ -344,8 +351,8 @@ class TestGetGrib:
     def test_make_hour_dirs_1km(
         self,
         m_get_file,
-        m_fix_perms,
         m_mkdir,
+        mock_fix_perms,
         forecast,
         resolution,
         config,
@@ -387,8 +394,8 @@ class TestGetGrib:
         self,
         m_session,
         m_get_file,
-        m_fix_perms,
         m_mkdir,
+        mock_fix_perms,
         forecast,
         resolution,
         variables,
@@ -427,6 +434,7 @@ class TestGetGrib:
         )
         assert kwargs == {}
 
+    @patch("nowcast.workers.download_weather.lib.fix_perms", autospec=True)
     @pytest.mark.parametrize(
         "forecast, resolution, variable",
         (
@@ -440,8 +448,8 @@ class TestGetGrib:
     )
     def test_fix_perms(
         self,
-        m_get_file,
         m_fix_perms,
+        m_get_file,
         m_mkdir,
         forecast,
         resolution,
@@ -479,8 +487,8 @@ class TestGetGrib:
     def test_checklist_2_5km(
         self,
         m_get_file,
-        m_fix_perms,
         m_mkdir,
+        mock_fix_perms,
         forecast,
         resolution,
         config,
@@ -510,8 +518,8 @@ class TestGetGrib:
     def test_checklist_1km(
         self,
         m_get_file,
-        m_fix_perms,
         m_mkdir,
+        mock_fix_perms,
         forecast,
         resolution,
         config,

--- a/tests/workers/test_download_weather.py
+++ b/tests/workers/test_download_weather.py
@@ -302,7 +302,9 @@ class TestGetGrib:
 
         monkeypatch.setattr(download_weather.lib, "fix_perms", _mock_fix_perms)
 
-    def test_log_messages(self, m_get_file, m_mkdir, mock_fix_perms, config, caplog):
+    def test_log_messages(
+        self, m_get_file, m_mkdir, mock_fix_perms, config, caplog, monkeypatch
+    ):
         parsed_args = SimpleNamespace(
             forecast="00",
             resolution="2.5km",
@@ -310,14 +312,12 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
-        p_config = patch.dict(
-            config["weather"]["download"]["2.5 km"],
-            {"forecast duration": 6},
+        monkeypatch.setitem(
+            config["weather"]["download"]["2.5 km"], "forecast duration", 6
         )
         caplog.set_level(logging.DEBUG)
 
-        with p_config:
-            download_weather.get_grib(parsed_args, config)
+        download_weather.get_grib(parsed_args, config)
 
         assert caplog.records[0].levelname == "INFO"
         expected = f"downloading 00 2.5 km forecast GRIB2 files for 20250507"
@@ -346,6 +346,8 @@ class TestGetGrib:
         forecast,
         resolution,
         config,
+        caplog,
+        monkeypatch,
     ):
         parsed_args = SimpleNamespace(
             forecast=forecast,
@@ -354,13 +356,12 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
-        p_config = patch.dict(
-            config["weather"]["download"][resolution.replace("km", " km")],
-            {"forecast duration": 6},
+        monkeypatch.setitem(
+            config["weather"]["download"]["2.5 km"], "forecast duration", 6
         )
+        caplog.set_level(logging.DEBUG)
 
-        with p_config:
-            download_weather.get_grib(parsed_args, config)
+        download_weather.get_grib(parsed_args, config)
 
         for hr in range(1, 7):
             args, kwargs = m_mkdir.call_args_list[hr + 1]
@@ -385,6 +386,8 @@ class TestGetGrib:
         forecast,
         resolution,
         config,
+        caplog,
+        monkeypatch,
     ):
         parsed_args = SimpleNamespace(
             forecast=forecast,
@@ -393,13 +396,12 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
-        p_config = patch.dict(
-            config["weather"]["download"][resolution.replace("km", " km")],
-            {"forecast duration": 6},
+        monkeypatch.setitem(
+            config["weather"]["download"]["1 km"], "forecast duration", 6
         )
+        caplog.set_level(logging.DEBUG)
 
-        with p_config:
-            download_weather.get_grib(parsed_args, config)
+        download_weather.get_grib(parsed_args, config)
 
         for hr in range(1, 7):
             args, kwargs = m_mkdir.call_args_list[hr + 1]
@@ -431,6 +433,8 @@ class TestGetGrib:
         resolution,
         variables,
         config,
+        caplog,
+        monkeypatch,
     ):
         parsed_args = SimpleNamespace(
             forecast=forecast,
@@ -439,13 +443,19 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
-        p_config = patch.dict(
+        monkeypatch.setitem(
             config["weather"]["download"][resolution.replace("km", " km")],
-            {"variables": [variables], "forecast duration": 1},
+            "variables",
+            [variables],
         )
+        monkeypatch.setitem(
+            config["weather"]["download"][resolution.replace("km", " km")],
+            "forecast duration",
+            1,
+        )
+        caplog.set_level(logging.DEBUG)
 
-        with p_config:
-            download_weather.get_grib(parsed_args, config)
+        download_weather.get_grib(parsed_args, config)
 
         args, kwargs = m_get_file.call_args
         variable = variables[0] if resolution == "2.5km" else variables
@@ -486,6 +496,8 @@ class TestGetGrib:
         resolution,
         variable,
         config,
+        caplog,
+        monkeypatch,
     ):
         parsed_args = SimpleNamespace(
             forecast=forecast,
@@ -494,14 +506,21 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
-        p_config = patch.dict(
+        monkeypatch.setitem(
             config["weather"]["download"][resolution.replace("km", " km")],
-            {"variables": [variable], "forecast duration": 1},
+            "variables",
+            [variable],
         )
+        monkeypatch.setitem(
+            config["weather"]["download"][resolution.replace("km", " km")],
+            "forecast duration",
+            1,
+        )
+        caplog.set_level(logging.DEBUG)
         m_get_file.return_value = "filepath"
         p_fix_perms = patch("nowcast.workers.download_weather.lib.fix_perms")
 
-        with p_config, p_fix_perms as m_fix_perms:
+        with p_fix_perms as m_fix_perms:
             download_weather.get_grib(parsed_args, config)
 
         m_fix_perms.assert_called_once_with("filepath")
@@ -523,6 +542,7 @@ class TestGetGrib:
         forecast,
         resolution,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             forecast=forecast,
@@ -531,6 +551,7 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
+        caplog.set_level(logging.DEBUG)
 
         checklist = download_weather.get_grib(parsed_args, config)
 
@@ -554,6 +575,7 @@ class TestGetGrib:
         forecast,
         resolution,
         config,
+        caplog,
     ):
         parsed_args = SimpleNamespace(
             forecast=forecast,
@@ -562,6 +584,7 @@ class TestGetGrib:
             no_verify_certs=False,
             backfill=False,
         )
+        caplog.set_level(logging.DEBUG)
 
         checklist = download_weather.get_grib(parsed_args, config)
 

--- a/tests/workers/test_download_weather.py
+++ b/tests/workers/test_download_weather.py
@@ -364,7 +364,9 @@ class TestGetGrib:
 
         for hr in range(1, 7):
             args, kwargs = m_mkdir.call_args_list[hr + 1]
-            expected = f"/results/forcing/atmospheric/continental{float(resolution[:-2]):.1f}/GRIB/20230224/{forecast}/00{hr}"
+            expected = Path(
+                f"/results/forcing/atmospheric/continental{float(resolution[:-2]):.1f}/GRIB/20230224/{forecast}/00{hr}"
+            )
             assert args[0] == expected
             assert kwargs == {"grp_name": "allen", "exist_ok": False}
 
@@ -401,7 +403,9 @@ class TestGetGrib:
 
         for hr in range(1, 7):
             args, kwargs = m_mkdir.call_args_list[hr + 1]
-            expected = f"/results/forcing/atmospheric/GEM{float(resolution[:-2]):.1f}/GRIB/20230224/{forecast}/00{hr}"
+            expected = Path(
+                f"/results/forcing/atmospheric/GEM{float(resolution[:-2]):.1f}/GRIB/20230224/{forecast}/00{hr}"
+            )
             assert args[0] == expected
             assert kwargs == {"grp_name": "allen", "exist_ok": False}
 


### PR DESCRIPTION
Introduces a `--backfill` CLI option to allow recovery from automation failures by skipping directory existence checks. Updates related tests and modifies `_mkdirs` to handle the new `backfill` option for directory creation.

re: issue #309