### PR TITLE
Fix wave height and period obs processing

### DIFF
--- a/nowcast/figures/wwatch3/wave_height_period.py
+++ b/nowcast/figures/wwatch3/wave_height_period.py
@@ -94,10 +94,16 @@ def _prep_plot_data(buoy, wwatch3_dataset_url):
     )
     try:
         obs = moad_tools.observations.get_ndbc_buoy(buoy)
+        wave_height = obs.loc[wwatch3_period, ("WVHT", "m")]
+        dominant_period = obs.loc[wwatch3_period, ("DPD", "sec")]
+        # Filter out missing values and cast to correct data types because presence of "MM"
+        # forces the data type to "object"
+        wave_height = wave_height[wave_height != "MM"].apply(float)
+        dominant_period = dominant_period[dominant_period != "MM"].apply(int)
         obs = xarray.Dataset(
             {
-                "wave_height": obs.loc[wwatch3_period, ("WVHT", "m")],
-                "dominant_period": obs.loc[wwatch3_period, ("DPD", "sec")],
+                "wave_height": wave_height.to_xarray(),
+                "dominant_period": dominant_period.to_xarray(),
             }
         )
     except ValueError:


### PR DESCRIPTION
Figure generation was failing when there were missing observations in the data obtained from NDBC. It appears that NDBC recently changed the missing data indicator to "MM". This commit handles missing values in wave height and dominant period data by filtering out "MM" entries and casting the Series to correct data types. The casting is necessary because the "MM" causes the Series to have "object" dtypes instead of numeric ones.