### PR TITLE
Correct `make_plots wwatch3` run type selection logic

### DIFF
--- a/nowcast/next_workers.py
+++ b/nowcast/next_workers.py
@@ -1623,7 +1623,7 @@ def after_ping_erddap(msg, config, checklist):
     if msg.type == "success wwatch3-forecast":
         try:
             run_types = checklist["WWATCH3 run"].keys()
-            run_type = "forecast2" if "forecast2" in run_types else "forecast"
+            run_type = "forecast" if "forecast" in run_types else "forecast2"
             run_date = checklist["WWATCH3 run"][run_type]["run date"]
         except KeyError:
             # Handling for the occasional occurrence of missing "WWATCH3 run" item in checklist


### PR DESCRIPTION
Switched the primary check to prioritize "forecast" over "forecast2" when determining the `make_plots wwatch3` run type. This ensures consistent and accurate handling of run types based on the checklist structure.