### PR TITLE
Update ERDDAP weather dataset ID in config & tests

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -478,7 +478,7 @@ erddap:
     weather:
       # List of ERDDAP dataset ids to create flag files for to signal updates
       # to ERDDAP server
-      - ubcSSaSurfaceAtmosphereFieldsV1
+      - ubcSSaSurfaceAtmosphereFieldsV23-02
     SCVIP-CTD:
       - ubcONCSCVIPCTD15mV1
     SEVIP-CTD:

--- a/tests/workers/test_ping_erddap.py
+++ b/tests/workers/test_ping_erddap.py
@@ -134,7 +134,9 @@ class TestConfig:
     def test_erddap_section(self, prod_config):
         erddap = prod_config["erddap"]
         assert erddap["flag dir"] == "/results/erddap/flag/"
-        assert erddap["datasetIDs"]["weather"] == ["ubcSSaSurfaceAtmosphereFieldsV1"]
+        assert erddap["datasetIDs"]["weather"] == [
+            "ubcSSaSurfaceAtmosphereFieldsV23-02"
+        ]
         assert erddap["datasetIDs"]["SCVIP-CTD"] == ["ubcONCSCVIPCTD15mV1"]
         assert erddap["datasetIDs"]["SEVIP-CTD"] == ["ubcONCSEVIPCTD15mV1"]
         # USDDL-CTD went out of service since 22-Dec-2019; repair ETA unknown


### PR DESCRIPTION
Revised the ERDDAP `weather` dataset ID from `ubcSSaSurfaceAtmosphereFieldsV1` to
`ubcSSaSurfaceAtmosphereFieldsV23-02` in `nowcast.yaml` and the corresponding test file. This was missed when we switched to the HRDPS continental rotated lon-lat product, but the oversight was hidden by ERDDAP doing dataset updates every 10 minutes. The ERDDAP behaviour was recently dropped, resulting in this issue being surfaced.