### PR TITLE
Update LiveOcean file URL templates in config & tests

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -222,10 +222,10 @@ temperature salinity:
   download:
     # Template for UW LiveOcean day-averaged forecast fields file processing status URL
     # **Must be quoted to project {} characters**
-    status file url template: 'https://liveocean.apl.uw.edu/output/f{yyyymmdd}/ubc_done.txt'
+    status file url template: "https://s3.kopah.uw.edu/liveocean-share/f{yyyymmdd}/ubc_done.txt"
     # Template for UW LiveOcean day-averaged forecast fields file URL
     # **Must be quoted to project {} characters**
-    bc file url template: 'https://liveocean.apl.uw.edu/output/f{yyyymmdd}/ubc.nc'
+    bc file url template: "https://s3.kopah.uw.edu/liveocean-share/f{yyyymmdd}/ubc.nc"
     # Destination directory for downloaded UW LiveOcean files
     dest dir: /results/forcing/LiveOcean/downloaded/
     # File name for local storage of UW LiveOcean day-averaged forecast file

--- a/tests/workers/test_download_live_ocean.py
+++ b/tests/workers/test_download_live_ocean.py
@@ -105,11 +105,11 @@ class TestConfig:
         download = prod_config["temperature salinity"]["download"]
         assert (
             download["status file url template"]
-            == "https://liveocean.apl.uw.edu/output/f{yyyymmdd}/ubc_done.txt"
+            == "https://s3.kopah.uw.edu/liveocean-share/f{yyyymmdd}/ubc_done.txt"
         )
         assert (
             download["bc file url template"]
-            == "https://liveocean.apl.uw.edu/output/f{yyyymmdd}/ubc.nc"
+            == "https://s3.kopah.uw.edu/liveocean-share/f{yyyymmdd}/ubc.nc"
         )
         assert download["dest dir"] == "/results/forcing/LiveOcean/downloaded/"
         assert download["file name"] == "low_passed_UBC.nc"


### PR DESCRIPTION
Switched URLs in `nowcast.yaml` and related test file to new S3 bucket paths for LiveOcean forecast files and status files. Updated to maintain alignment with the new data source location.