### PR TITLE
Fix bugs in GHA pytest workflow

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -21,6 +21,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Get current date for downloads cache key
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+
       - name: Set up Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462
         with:


### PR DESCRIPTION
* Replaced `inputs.python-version` with `matrix.python-version` in the pytest-with-coverage workflow. This fixes a copy-paste error from the reusable `pytest-with-coverage` workflow where the Python version is an input.
* Introduced a missing step to generate a date-based cache key for downloads in 
the pytest-with-coverage workflow. This ensures that downloads are cached for 1 
day. It is unclear how long the downloads were cached previously when the date 
part of the cache key was empty.