### PR TITLE
Avoid `sphinx-linkcheck` GHA workflow timeouts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,13 @@ linkcheck_ignore = [
     "https://github.com/SalishSeaCast/tidal-predictions",
     "https://polar.ncep.noaa.gov/waves/wavewatch/distribution/",
 ]
+if os.environ.get("GITHUB_ACTIONS") == "true":
+    # When we run on GitHub Actions, ignore a collection of URLs that have timeouts due to rate limiting
+    linkcheck_ignore.extend(
+        [
+            r"https://alliancecan.ca/.*",
+        ]
+    )
 
 todo_include_todos = True
 


### PR DESCRIPTION
Added a URL pattern to the `linkcheck_ignore` list to bypass timeouts caused by rate limits when running the `sphinx-linkcheck` workflow in GitHub Actions. This reduces false flags in documentation link checks in CI.