### PR TITLE
Add unique suffix to downloads cache key

### DIFF
--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -34,7 +34,7 @@ jobs:
            cache-environment: false
            cache-downloads: true
            # persist downloads cache for 1 day
-           cache-downloads-key: downloads-${{ steps.date.outputs.date }}
+           cache-downloads-key: downloads-${{ steps.date.outputs.date }}-pytest
            create-args: >-
              python=${{ matrix.python-version }}
 


### PR DESCRIPTION
This is necessary for the `pytest-with-coverage` workflow that uses `micromamba` in order to avoid errors like "Unable to reserve cache with key downloads-2025-11-23-linux-64, another job may be creating this cache".