### PR TITLE
Delete ECCC GRIB files after `crop_gribs` processing

### DIFF
--- a/nowcast/workers/crop_gribs.py
+++ b/nowcast/workers/crop_gribs.py
@@ -323,6 +323,7 @@ class _GribFileEventHandler(watchdog.events.FileSystemEventHandler):
             eccc_grib_file = Path(event.src_path)
             _write_ssc_grib_file(eccc_grib_file, self.config)
             self.eccc_grib_files.remove(eccc_grib_file)
+            eccc_grib_file.unlink()
             logger.debug(
                 f"observer thread files remaining to process: {len(self.eccc_grib_files)}"
             )

--- a/tests/workers/test_crop_gribs.py
+++ b/tests/workers/test_crop_gribs.py
@@ -727,6 +727,7 @@ class TestGribFileEventHandler:
         expected = f"observer thread files remaining to process: 0"
         assert caplog.messages[0] == expected
         assert eccc_grib_file not in eccc_grib_files
+        assert not eccc_grib_file.exists()
 
     def test_ignore_unexpected_file(self, config, caplog, tmp_path, monkeypatch):
         @attr.s
@@ -754,3 +755,4 @@ class TestGribFileEventHandler:
 
         assert not caplog.records
         assert eccc_grib_file in eccc_grib_files
+        assert eccc_grib_file.exists()


### PR DESCRIPTION
Added `unlink()` to remove downloaded ECCC GRIB files after we calculated the cropped version for SalishSeaCast forcing in the `crop_gribs` worker. Updated corresponding test cases to verify file removal. This prevents downloaded ECCC GRIB files from persisting unnecessarily, improving management of `/results/forcing/` storage.