### PR TITLE
Set "water depth units" col dtype in turbidity CSV

### DIFF
--- a/nowcast/workers/make_turbidity_file.py
+++ b/nowcast/workers/make_turbidity_file.py
@@ -128,7 +128,7 @@ def make_turbidity_file(parsed_args, config, *args):
 
 def _loadturb(idate, turbidity_csv, mthresh, ymd):
     # Read file into pandas dataframe
-    tdf = pd.read_csv(turbidity_csv, header=0)
+    tdf = pd.read_csv(turbidity_csv, header=0, dtype={"water depth units": str})
     tdf["dtdate"] = pd.to_datetime(
         tdf["# date"] + " " + tdf["time"], format="%Y-%m-%d %H:%M:%S"
     )


### PR DESCRIPTION
Specified the "water depth units" column as a string type when loading the turbidity CSV. This ensures consistent data handling and prevents potential issues from incorrect type inference due to mixture of `m` and `NaN` values in CSV.

re: issue #423