### PR TITLE
Use regex for CSV delimiter in make_runoff_file

### DIFF
--- a/nowcast/workers/make_runoff_file.py
+++ b/nowcast/workers/make_runoff_file.py
@@ -373,7 +373,7 @@ _read_river_csv = functools.partial(
     # .csv files
     pandas.read_csv,
     header=None,
-    delim_whitespace=True,
+    sep=r"\s+",
     index_col=False,
     names=["year", "month", "day", "flow"],
     engine="python",


### PR DESCRIPTION
Replaced `delim_whitespace=True` with `sep=r"\s+"` to define the delimiter using a regex. This resolves a `FutureWarning`:
>     The 'delim_whitespace' keyword in pd.read_csv is deprecated and
>     will be removed in a future version. Use ``sep='\s+'`` instead