### PR TITLE
Update `nibi` forcing file paths to use `rrg-allen`

### DIFF
--- a/config/nowcast.yaml
+++ b/config/nowcast.yaml
@@ -701,11 +701,11 @@ run:
       # files
       run types: {}
       forcing:
-        ssh dir: /project/def-allen/SalishSea/forcing/sshNeahBay/
-        bc dir: /project/def-allen/SalishSea/forcing/LiveOcean/
-        rivers dir: /project/def-allen/SalishSea/forcing/rivers/
-        Fraser turbidity dir: /project/def-allen/SalishSea/forcing/rivers/river_turb/
-        weather dir: /project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/
+        ssh dir: /project/rrg-allen/SalishSea/forcing/sshNeahBay/
+        bc dir: /project/rrg-allen/SalishSea/forcing/LiveOcean/
+        rivers dir: /project/rrg-allen/SalishSea/forcing/rivers/
+        Fraser turbidity dir: /project/rrg-allen/SalishSea/forcing/rivers/river_turb/
+        weather dir: /project/rrg-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/
 
     optimum-hindcast:
       ssh key: SalishSeaNEMO-nowcast_id_rsa

--- a/tests/workers/test_make_forcing_links.py
+++ b/tests/workers/test_make_forcing_links.py
@@ -178,7 +178,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/sshNeahBay/"),
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/sshNeahBay/"),
-            ("robot.nibi", "/project/def-allen/SalishSea/forcing/sshNeahBay/"),
+            ("robot.nibi", "/project/rrg-allen/SalishSea/forcing/sshNeahBay/"),
             (
                 "optimum-hindcast",
                 "/data/sallen/shared/SalishSeaCast/forcing/sshNeahBay/",
@@ -201,7 +201,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/rivers/"),
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/rivers/"),
-            ("robot.nibi", "/project/def-allen/SalishSea/forcing/rivers/"),
+            ("robot.nibi", "/project/rrg-allen/SalishSea/forcing/rivers/"),
             ("optimum-hindcast", "/data/sallen/shared/SalishSeaCast/forcing/rivers/"),
         ),
     )
@@ -218,7 +218,7 @@ class TestConfig:
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/rivers/river_turb/"),
             (
                 "robot.nibi",
-                "/project/def-allen/SalishSea/forcing/rivers/river_turb/",
+                "/project/rrg-allen/SalishSea/forcing/rivers/river_turb/",
             ),
             (
                 "optimum-hindcast",
@@ -251,7 +251,7 @@ class TestConfig:
             ),
             (
                 "robot.nibi",
-                "/project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
+                "/project/rrg-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
             ),
             (
                 "optimum-hindcast",
@@ -276,7 +276,7 @@ class TestConfig:
         (
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/LiveOcean/"),
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/LiveOcean/"),
-            ("robot.nibi", "/project/def-allen/SalishSea/forcing/LiveOcean/"),
+            ("robot.nibi", "/project/rrg-allen/SalishSea/forcing/LiveOcean/"),
             (
                 "optimum-hindcast",
                 "/data/sallen/shared/SalishSeaCast/forcing/LiveOcean/",

--- a/tests/workers/test_upload_forcing.py
+++ b/tests/workers/test_upload_forcing.py
@@ -61,7 +61,7 @@ def config(base_config):
                         robot.nibi:
                             ssh key: SalishSeaNEMO-nowcast_id_rsa
                             forcing:
-                                rivers dir: /project/def-allen/SalishSea/forcing/rivers/
+                                rivers dir: /project/rrg-allen/SalishSea/forcing/rivers/
                         optimum-hindcast:
                             ssh key: SalishSeaNEMO-nowcast_id_rsa
                             forcing:
@@ -160,7 +160,7 @@ class TestConfig:
                 "/data/sallen/shared/SalishSeaCast/forcing/sshNeahBay/",
             ),
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/sshNeahBay/"),
-            ("robot.nibi", "/project/def-allen/SalishSea/forcing/sshNeahBay/"),
+            ("robot.nibi", "/project/rrg-allen/SalishSea/forcing/sshNeahBay/"),
         ),
     )
     def test_ssh_uploads(self, host, ssh_key, prod_config):
@@ -179,7 +179,7 @@ class TestConfig:
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/rivers/river_turb/"),
             (
                 "robot.nibi",
-                "/project/def-allen/SalishSea/forcing/rivers/river_turb/",
+                "/project/rrg-allen/SalishSea/forcing/rivers/river_turb/",
             ),
         ),
     )
@@ -196,7 +196,7 @@ class TestConfig:
             ("arbutus.cloud-nowcast", "/nemoShare/MEOPAR/rivers/"),
             ("optimum-hindcast", "/data/sallen/shared/SalishSeaCast/forcing/rivers/"),
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/rivers/"),
-            ("robot.nibi", "/project/def-allen/SalishSea/forcing/rivers/"),
+            ("robot.nibi", "/project/rrg-allen/SalishSea/forcing/rivers/"),
         ),
     )
     def test_river_runoff_uploads(self, host, expected, prod_config):
@@ -223,7 +223,7 @@ class TestConfig:
             ),
             (
                 "robot.nibi",
-                "/project/def-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
+                "/project/rrg-allen/SalishSea/forcing/atmospheric/continental2.5/nemo_forcing/",
             ),
         ),
     )
@@ -246,7 +246,7 @@ class TestConfig:
                 "/data/sallen/shared/SalishSeaCast/forcing/LiveOcean/",
             ),
             ("orcinus-nowcast-agrif", "/global/home/sallen/MEOPAR/LiveOcean/"),
-            ("robot.nibi", "/project/def-allen/SalishSea/forcing/LiveOcean/"),
+            ("robot.nibi", "/project/rrg-allen/SalishSea/forcing/LiveOcean/"),
         ),
     )
     def test_live_ocean_uploads(self, host, expected, prod_config):


### PR DESCRIPTION
Replaced all occurrences of `/project/def-allen/SalishSea/forcing/` paths with `/project/rrg-allen/SalishSea/forcing/` across test files and configuration. This reflects change in the storage location on `nibi` and ensures code alignment with the updated paths.