### PR TITLE
Improve GitHub Actions workflows based on `zizmor` static analysis

### DIFF
--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -17,4 +17,4 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -1,5 +1,7 @@
 name: Add Milestone to Issue/PR
 
+permissions: {}
+
 on:
   issues:
     types:

--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   add_milestone:
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write  # Required to assign milestones to issues
+      pull-requests: write  # Required to add milestone to PRs
     uses: UBC-MOAD/gha-workflows/.github/workflows/auto-milestone-issue-pr.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/add-milestone-issue-pr.yaml
+++ b/.github/workflows/add-milestone-issue-pr.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   add_milestone:
+    name: Add current milestone to issue/PR
     permissions:
       issues: write  # Required to assign milestones to issues
       pull-requests: write  # Required to add milestone to PRs

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   auto_assign:
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write  # Required to add assignees to issues
+      pull-requests: write  # Required to add assignees to PRs
     uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   auto_assign:
+    name: Auto-assign issues and PRs to Doug
     permissions:
       issues: write  # Required to add assignees to issues
       pull-requests: write  # Required to add assignees to PRs

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -1,4 +1,7 @@
 name: Assign Issue/PR
+
+permissions: {}
+
 on:
   issues:
     types:
@@ -8,6 +11,7 @@ on:
     types:
       - reopened
       - opened
+
 jobs:
   auto_assign:
     permissions:

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -17,4 +17,4 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/auto-assign.yaml@main  # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -21,6 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'python' ]
-    uses: UBC-MOAD/gha-workflows/.github/workflows/codeql-analysis.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/codeql-analysis.yaml@main  # zizmor: ignore[unpinned-uses]
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -14,9 +14,9 @@ jobs:
   analyze:
     name: Analyze
     permissions:
-      actions: read
-      contents: read
-      security-events: write
+      actions: read  # Required to run CodeQL analysis
+      contents: read  # Required to check out the repo
+      security-events: write  # Required to upload CodeQL analysis results
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,5 +1,7 @@
 name: "CodeQL"
 
+permissions: {}
+
 on:
   push:
     branches: [ main, ]

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: CodeQL analysis for ${{ inputs.language }}
     permissions:
       actions: read  # Required to run CodeQL analysis
       contents: read  # Required to check out the repo

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
 
       - name: Get current date for downloads cache key
         id: date

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -12,8 +12,8 @@ on:
 jobs:
   pytest-with-coverage:
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read  # Required to check out the repo
+      pull-requests: write  # Required to comment on pull requests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   pytest-with-coverage:
+    name: pytest with coverage
     permissions:
       contents: read  # Required to check out the repo
       pull-requests: write  # Required to comment on pull requests

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -1,5 +1,7 @@
 name: pytest-with-coverage
 
+permissions: {}
+
 on:
   push:
     branches: ['*']

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6  # zizmor: ignore[unpinned-uses]
+        with:
+          persist-credentials: false  # Required to avoid exposing secrets to pytest run in forked PRs
 
       - name: Get current date for downloads cache key
         id: date

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -69,4 +69,4 @@ jobs:
         with:
           files: ./coverage.xml
           flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/pytest-with-coverage.yaml
+++ b/.github/workflows/pytest-with-coverage.yaml
@@ -9,6 +9,11 @@ on:
   # primarily for testing conda env solution for new Python versions
   workflow_dispatch:
 
+# Helps prevent parallel runs of the workflow from overlapping
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest-with-coverage:
     name: pytest with coverage

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -1,5 +1,7 @@
 name: sphinx-linkcheck
 
+permissions: {}
+
 on:
   push:
     branches: ['*']

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   sphinx-linkcheck:
+    name: Sphinx linkcheck
     permissions:
       contents: read  # Required to check out the repo
     strategy:

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -18,7 +18,7 @@ jobs:
         # Need to specify the Python version here because we use test env which gets its
         # Python version via matrix
         python-version: [ '3.13' ]
-    uses: UBC-MOAD/gha-workflows/.github/workflows/sphinx-linkcheck.yaml@main
+    uses: UBC-MOAD/gha-workflows/.github/workflows/sphinx-linkcheck.yaml@main  # zizmor: ignore[unpinned-uses]
     with:
       python-version: ${{ matrix.python-version }}
       conda-env-file: envs/environment-linkcheck.yaml

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   sphinx-linkcheck:
     permissions:
-      contents: read
+      contents: read  # Required to check out the repo
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
* locked down permissions in all workflows to prevent leakage of default permissions
* added pragma comments to tell `zizmor` to ignore unpinned uses of our own reusable workflows
* added explanatory comments to permissions items
* added pragma comments to tell `zizmor` to ignore major version pin instead of hash pin in `pytest-with-coverage` workflow on use of `actions/checkout` published by GitHub as a reasonable trade-off 
between security and convenience.
* added `perist-credentials: false` to `actions/checkout` uses to potential exposure of secrets in forked PRs
* added names to anonymous workflow jobs to improve readability in GHA UI
* added concurrency block to prevent overlapping runs of  `pytest-with-coverage` workflow
* added pragma comment to tell `zizmor` to ignore use of CodeCov secret outside of an environment
