### PR TITLE
Add `sphinx-copybutton` and improve code block formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ release = version
 # ones.
 extensions = [
     "notfound.extension",
+    "sphinx_copybutton",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,15 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
+# -- Options for sphinx_copybutton extension ------------------------------
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+# Add a `no-copybutton` class that can be used to suppress the copy button
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
+
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "nemonowcast": ("https://nemo-nowcast.readthedocs.io/en/latest/", None),

--- a/docs/deployment/arbutus_cloud.rst
+++ b/docs/deployment/arbutus_cloud.rst
@@ -261,9 +261,11 @@ You can list the keys that the agent is managing for you with:
 
     $ ssh-add -l
 
-You can simplify logins to the instance by adding the following lines to your :file:`$HOME/.ssh/config` file::
+You can simplify logins to the instance by adding the following lines to your :file:`$HOME/.ssh/config` file:
 
-  Host arbutus.cloud
+.. code-block:: text
+
+    Host arbutus.cloud
       Hostname        <ip-address>
       User            ubuntu
       IdentityFile    ~/.ssh/arbutus.cloud_id_rsa
@@ -374,15 +376,17 @@ Confirm that the :ref:`PersistentSharedStorage` volume is attached on ``vdc`` wi
 
     $ sudo lsblk -f
 
-The expected output is like::
+The expected output is like:
 
-  NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
-  vda
-  ├─vda1  ext4   cloudimg-rootfs 5e99de08-0334-45c0-82a2-7938eb21ac53 /
-  ├─vda14
-  └─vda15 vfat   UEFI            B60C-5465                            /boot/efi
-  vdb     ext4   ephemeral0      5f16e568-7cff-4a88-a51c-b3c0bd50803c /mnt
-  vdc
+.. code-block:: text
+
+    NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
+    vda
+    ├─vda1  ext4   cloudimg-rootfs 5e99de08-0334-45c0-82a2-7938eb21ac53 /
+    ├─vda14
+    └─vda15 vfat   UEFI            B60C-5465                            /boot/efi
+    vdb     ext4   ephemeral0      5f16e568-7cff-4a88-a51c-b3c0bd50803c /mnt
+    vdc
 
 
 Format the volume with an `ext4` file system and confirm:
@@ -392,15 +396,17 @@ Format the volume with an `ext4` file system and confirm:
     $ sudo mkfs.ext4 /dev/vdc
     $ sudo lsblk -f
 
-The expected output is like::
+The expected output is like:
 
-  NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
-  vda
-  ├─vda1  ext4   cloudimg-rootfs 5e99de08-0334-45c0-82a2-7938eb21ac53 /
-  ├─vda14
-  └─vda15 vfat   UEFI            B60C-5465                            /boot/efi
-  vdb     ext4   ephemeral0      5f16e568-7cff-4a88-a51c-b3c0bd50803c /mnt
-  vdc     ext4                   381a0eb2-9429-42b2-9be0-1ddb53087f94
+.. code-block:: text
+
+    NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
+    vda
+    ├─vda1  ext4   cloudimg-rootfs 5e99de08-0334-45c0-82a2-7938eb21ac53 /
+    ├─vda14
+    └─vda15 vfat   UEFI            B60C-5465                            /boot/efi
+    vdb     ext4   ephemeral0      5f16e568-7cff-4a88-a51c-b3c0bd50803c /mnt
+    vdc     ext4                   381a0eb2-9429-42b2-9be0-1ddb53087f94
 
 Create the :file:`/nemoShare/` mount point,
 mount the volume,
@@ -421,14 +427,18 @@ Reference: https://help.ubuntu.com/community/SettingUpNFSHowTo
     $ sudo mkdir -p /export/MEOPAR
     $ sudo mount --bind /nemoShare/MEOPAR /export/MEOPAR
 
-Add the following line to :file:`/etc/fstab`::
+Add the following line to :file:`/etc/fstab`:
 
-  /nemoShare/MEOPAR   /export/MEOPAR  none  bind  0  0
+.. code-block:: text
 
-Add the following lines to :file:`/etc/exports`::
+    /nemoShare/MEOPAR   /export/MEOPAR  none  bind  0  0
 
-  /export        192.168.238.0/24(rw,fsid=0,insecure,no_subtree_check,async)
-  /export/MEOPAR 192.168.238.0/24(rw,nohide,insecure,no_subtree_check,async)
+Add the following lines to :file:`/etc/exports`:
+
+.. code-block:: console
+
+    /export        192.168.238.0/24(rw,fsid=0,insecure,no_subtree_check,async)
+    /export/MEOPAR 192.168.238.0/24(rw,nohide,insecure,no_subtree_check,async)
 
 Restart the NFS service:
 
@@ -527,76 +537,82 @@ and MPI hosts mapping files for NEMO/WAVEWATCH VMs and FVCOM VMs on the head nod
 Head Node :file:`.ssh/config`
 -----------------------------
 
-::
+.. code-block:: text
 
-  Host *
+    Host *
        StrictHostKeyChecking no
 
-  # Head node and XIOS host
-  Host nowcast0
+    # Head node and XIOS host
+    Host nowcast0
     HostName 192.168.238.14
 
-  # NEMO compute nodes
-  Host nowcast1
+    # NEMO compute nodes
+    Host nowcast1
     HostName 192.168.238.10
-  Host nowcast2
+    Host nowcast2
     HostName 192.168.238.13
-  Host nowcast3
-   HostName 192.168.238.8
-  Host nowcast4
+    Host nowcast3
+    HostName 192.168.238.8
+    Host nowcast4
     HostName 192.168.238.16
-  Host nowcast5
+    Host nowcast5
     HostName 192.168.238.5
-  Host nowcast6
+    Host nowcast6
     HostName 192.168.238.6
-  Host nowcast7
+    Host nowcast7
     HostName 192.168.238.18
-  Host nowcast8
+    Host nowcast8
     HostName 192.168.238.15
 
-  # FVCOM compute nodes
-  Host fvcom0
+    # FVCOM compute nodes
+    Host fvcom0
     HostName 192.168.238.12
-  Host fvcom1
+    Host fvcom1
     HostName 192.168.238.7
-  Host fvcom2
+    Host fvcom2
     HostName 192.168.238.20
-  Host fvcom3
+    Host fvcom3
     HostName 192.168.238.11
-  Host fvcom4
+    Host fvcom4
     HostName 192.168.238.9
-  Host fvcom5
+    Host fvcom5
     HostName 192.168.238.28
-  Host fvcom6
+    Host fvcom6
     HostName 192.168.238.27
 
 
 MPI Hosts Mappings
 ------------------
 
-:file:`$HOME/mpi_hosts` for NEMO/WAVEWATCH VMs containing::
+:file:`$HOME/mpi_hosts` for NEMO/WAVEWATCH VMs containing:
 
-  192.168.238.10 slots=15 max-slots=16
-  192.168.238.13 slots=15 max-slots=16
-  192.168.238.8  slots=15 max-slots=16
-  192.168.238.16 slots=15 max-slots=16
-  192.168.238.5  slots=15 max-slots=16
-  192.168.238.6  slots=15 max-slots=16
-  192.168.238.18 slots=15 max-slots=16
-  192.168.238.15 slots=15 max-slots=16
+.. code-block:: text
 
-:file:`$HOME/mpi_hosts.fvcom.x2` for FVCOM VMs used for ``x2`` model configuration runs containing::
+    192.168.238.10 slots=15 max-slots=16
+    192.168.238.13 slots=15 max-slots=16
+    192.168.238.8  slots=15 max-slots=16
+    192.168.238.16 slots=15 max-slots=16
+    192.168.238.5  slots=15 max-slots=16
+    192.168.238.6  slots=15 max-slots=16
+    192.168.238.18 slots=15 max-slots=16
+    192.168.238.15 slots=15 max-slots=16
 
-  192.168.238.12 slots=15 max-slots=16
-  192.168.238.7  slots=15 max-slots=16
+:file:`$HOME/mpi_hosts.fvcom.x2` for FVCOM VMs used for ``x2`` model configuration runs containing:
 
-:file:`$HOME/mpi_hosts.fvcom.r12` for FVCOM VMs used for ``r12`` model configuration runs containing::
+.. code-block:: text
 
-  192.168.238.20 slots=15 max-slots=16
-  192.168.238.11 slots=15 max-slots=16
-  192.168.238.9  slots=15 max-slots=16
-  192.168.238.28 slots=15 max-slots=16
-  192.168.238.27 slots=15 max-slots=16
+    192.168.238.12 slots=15 max-slots=16
+    192.168.238.7  slots=15 max-slots=16
+
+:file:`$HOME/mpi_hosts.fvcom.r12` for FVCOM VMs used for ``r12`` model configuration runs containing:
+
+.. code-block:: text
+
+    192.168.238.20 slots=15 max-slots=16
+    192.168.238.11 slots=15 max-slots=16
+    192.168.238.9  slots=15 max-slots=16
+    192.168.238.28 slots=15 max-slots=16
+    192.168.238.27 slots=15 max-slots=16
 
 
 Git Repositories

--- a/docs/deployment/arbutus_cloud.rst
+++ b/docs/deployment/arbutus_cloud.rst
@@ -71,7 +71,7 @@ Access & Security
 
 Generate an ssh key pair on a Linux or OS/X system using the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $HOME/.ssh/
     $ ssh -t rsa -b 4096 -f ~/.ssh/arbutus.cloud_id_rsa -C <yourname>-arbutus.cloud
@@ -237,7 +237,7 @@ Use :guilabel:`Actions > Manage Attachments` to attach the volume to the ``nowca
 
 Log in to the publicly accessible head node instance with the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh -i $HOME/.ssh/arbutus.cloud_id_rsa ubuntu@<ip-address>
 
@@ -251,13 +251,13 @@ You will also be prompted for the passphrase that you assigned to the ssh key pa
 On Linux and OS/X authenticating the ssh key with your passphrase has the side-effect of adding it to the :command:`ssh-agent` instance that was started when you logged into the system.
 You can add the key to the agent yourself with the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh-add $HOME/.ssh/arbutus.cloud_id_rsa
 
 You can list the keys that the agent is managing for you with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh-add -l
 
@@ -273,7 +273,7 @@ You can simplify logins to the instance by adding the following lines to your :f
 
 With that in place you should be able to connect to the instance with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh arbutus.cloud
 
@@ -287,7 +287,7 @@ Head Node
 Fetch and apply any available updates on the ``nowcast0`` :ref:`HeadNodeInstance`
 that you launched above with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo apt update
     $ sudo apt upgrade
@@ -295,7 +295,7 @@ that you launched above with:
 
 Set the timezone with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo timedatectl set-timezone America/Vancouver
 
@@ -304,13 +304,13 @@ time,
 time zone,
 and that the ``systemd-timesyncd.service`` is activate with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ timedatectl status
 
 Provision the :ref:`HeadNodeInstance` with the following packages:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo apt update
     $ sudo apt install -y mercurial git
@@ -325,14 +325,14 @@ Provision the :ref:`HeadNodeInstance` with the following packages:
 
 Copy the public key of the passphrase-less ssh key pair that will be used for nowcast cloud operations into :file:`$HOME/.ssh/authorized_keys` pm the head node:
 
-.. code-block:: bash
+.. code-block:: console
 
     # on a system where they key pair is stored
     $ ssh-copy-id -f -i $HOME/.ssh/SalishSeaNEMO-nowcast_id_rsa arbutus.cloud
 
 Copy the passphrase-less ssh key pair that will be used for nowcast cloud operations into :file:`$HOME/.ssh/` as :file:`id_rsa` and :file:`id_rsa.pub` for :command:`mpirun` to use for communication with the compute instances:
 
-.. code-block:: bash
+.. code-block:: console
 
     # on a system where they key pair is stored
     $ scp $HOME/.ssh/SalishSeaNEMO-nowcast_id_rsa arbutus.cloud:.ssh/id_rsa
@@ -346,7 +346,7 @@ the possibility of revoking the passphrase-less key pair without loosing access 
 Add code to :file:`$HOME/.profile` to add wwatch3 :file:`bin/` and :file:`exe/` paths to :envvar:`PATH` if they exist,
 and export environment variables to enable wwatch3 to use netCDF4:
 
-.. code-block:: bash
+.. code-block:: console
 
     # Add wwatch3 bin/ and exe/ paths to PATH if they exist
     if [ -d "/nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin" ] ; then
@@ -362,7 +362,7 @@ and export environment variables to enable wwatch3 to use netCDF4:
 
 Create :file:`$HOME/.bash_aliases` containing a command to make :command:`rm` default to prompting for confirmation:
 
-.. code-block:: bash
+.. code-block:: console
 
     alias rm="rm -i"
 
@@ -372,7 +372,7 @@ Shared Persistent Storage
 
 Confirm that the :ref:`PersistentSharedStorage` volume is attached on ``vdc`` with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo lsblk -f
 
@@ -391,7 +391,7 @@ The expected output is like:
 
 Format the volume with an `ext4` file system and confirm:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo mkfs.ext4 /dev/vdc
     $ sudo lsblk -f
@@ -412,7 +412,7 @@ Create the :file:`/nemoShare/` mount point,
 mount the volume,
 and set the owner and group:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo mkdir /nemoShare
     $ sudo mount /dev/vdc /nemoShare
@@ -422,7 +422,7 @@ Set up the NFS server service to provide access to the shared storage on the com
 
 Reference: https://help.ubuntu.com/community/SettingUpNFSHowTo
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo mkdir -p /export/MEOPAR
     $ sudo mount --bind /nemoShare/MEOPAR /export/MEOPAR
@@ -442,7 +442,7 @@ Add the following lines to :file:`/etc/exports`:
 
 Restart the NFS service:
 
-  .. code-block:: bash
+  .. code-block:: console
 
     $ sudo systemctl start nfs-kernel-server.service
 
@@ -452,7 +452,7 @@ Compute Node Template
 
 Fetch and apply any available updates on the ``nowcast1`` :ref:`ComputeNodeInstance` that you launched above with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo apt update
     $ sudo apt upgrade
@@ -460,7 +460,7 @@ Fetch and apply any available updates on the ``nowcast1`` :ref:`ComputeNodeInsta
 
 Set the timezone with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo timedatectl set-timezone America/Vancouver
 
@@ -469,13 +469,13 @@ time,
 time zone,
 and that the ``systemd-timesyncd.service`` is activate with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ timedatectl status
 
 Provision the :ref:`HeadNodeInstance` with the following packages:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo apt update
     $ sudo apt install -y gfortran
@@ -487,7 +487,7 @@ Provision the :ref:`HeadNodeInstance` with the following packages:
 Add code to :file:`$HOME/.profile` to add wwatch3 :file:`bin/` and :file:`exe/` paths to :envvar:`PATH` if they exist,
 and export environment variables to enable wwatch3 to use netCDF4:
 
-.. code-block:: bash
+.. code-block:: console
 
     # Add wwatch3 bin/ and exe/ paths to PATH if they exist
     if [ -d "/nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin" ] ; then
@@ -503,14 +503,14 @@ and export environment variables to enable wwatch3 to use netCDF4:
 
 Create :file:`$HOME/.bash_aliases` containing a command to make :command:`rm` default to prompting for confirmation:
 
-.. code-block:: bash
+.. code-block:: console
 
     alias rm="rm -i"
 
 Create the :file:`/nemoShare/` mount point,
 and set the owner and group:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ sudo mkdir -p /nemoShare/MEOPAR
     $ sudo chown ubuntu:ubuntu /nemoShare/ /nemoShare/MEOPAR/
@@ -518,7 +518,7 @@ and set the owner and group:
 From the head node,
 copy the public key of the passphrase-less ssh key pair that will be used for nowcast cloud operations into :file:`$HOME/.ssh/authorized_keys` on the compute node:
 
-.. code-block:: bash
+.. code-block:: console
 
     # on nowcast0
     $ ssh-copy-id -f -i $HOME/.ssh/id_rsa nowcast1
@@ -620,7 +620,7 @@ Git Repositories
 
 Clone the following repos into :file:`/nemoShare/MEOPAR/nowcast-sys/`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/
     $ git clone git@github.com:SalishSeaCast/grid.git
@@ -644,7 +644,7 @@ Build XIOS-2
 
 Symlink the XIOS-2 build configuration files for ``arbutus.cloud`` from the :file:`XIOS-ARCH` repo clone into the :file:`XIOS-2/arch/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/XIOS-2/arch
     $ ln -s ../../XIOS-ARCH/COMPUTECANADA/arch-GCC_ARBUTUS.fcm
@@ -652,7 +652,7 @@ Symlink the XIOS-2 build configuration files for ``arbutus.cloud`` from the :fil
 
 Build XIOS-2 with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/XIOS-2
     $ ./make_xios --arch GCC_ARBUTUS --netcdf_lib netcdf4_seq --job 8
@@ -663,7 +663,7 @@ Build NEMO-3.6
 
 Build NEMO-3.6 and :program:`rebuild_nemo.exe`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/NEMO-3.6-code/NEMOGCM/CONFIG
     $ XIOS_HOME=/nemoShare/MEOPAR/nowcast-sys/XIOS-2 ./makenemo -m GCC_ARBUTUS -n SalishSeaCast -j8
@@ -682,7 +682,7 @@ Access to download WAVEWATCH III :sup:`®`
 code tarballs is obtained by sending an email request from the https://polar.ncep.noaa.gov/waves/wavewatch/license.shtml.
 The eventual reply will provide a username and password that can be used to access https://polar.ncep.noaa.gov/waves/wavewatch/distribution/ from which the :file:`wwatch3.v5.16.tar.gz` files can be downloaded with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/
     $ curl -u username:password -LO download_url
@@ -696,7 +696,7 @@ that will use the :program:`gfortran` and :program:`gcc` compilers:
 
 .. _wwatch3 manual: https://polar.ncep.noaa.gov/waves/wavewatch/manual.v5.16.pdf
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir /nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16
     $ cd /nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16
@@ -715,7 +715,7 @@ Ensure that :file:`/nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin` and :file:`/n
 Change the :file:`comp` and :file:`link` scripts in :file:`/nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin` to point to :file:`comp.gnu` and :file:`link.gnu`,
 and make :file:`comp.gnu` executable:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin
     $ ln -sf comp.gnu comp && chmod +x comp.gnu
@@ -723,21 +723,21 @@ and make :file:`comp.gnu` executable:
 
 Symlink the :file:`SalishSeaWaves/switch` file in :file:`/nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/bin
     $ ln -sf /nemoShare/MEOPAR/nowcast-sys/SalishSeaWaves/switch switch
 
 Export the :envvar:`WWATCH3_NETCDF` and :envvar:`NETCDF_CONFIG` environment variables:
 
-.. code-block:: bash
+.. code-block:: console
 
     export WWATCH3_NETCDF=NC4
     export NETCDF_CONFIG=$(which nc-config)
 
 Build the suite of wwatch3 programs with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/wwatch3-5.16/work
     $ w3_make
@@ -751,7 +751,7 @@ Install the `Miniforge-pypy3`_ environment and package manager:
 .. _Miniforge-pypy3: https://github.com/conda-forge/miniforge
 
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/
     $ curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-Linux-x86_64.sh
@@ -763,7 +763,7 @@ Answer ``yes`` when the install asks :guilabel:`Do you wish to update your shell
 
 The Python packages that the system depends on are installed in a conda environment with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/
     $ mamba env create \
@@ -783,7 +783,7 @@ Environment Variables
 
 Add the following files to the :file:`/nemoShare/MEOPAR/nowcast-sys/nowcast-env` environment to automatically :command:`export` the environment variables required by the nowcast system when the environment is activated:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/nowcast-env
     $ mkdir -p etc/conda/activate.d
@@ -798,7 +798,7 @@ Add the following files to the :file:`/nemoShare/MEOPAR/nowcast-sys/nowcast-env`
 
 and :command:`unset` them when it is deactivated.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p etc/conda/deactivate.d
     $ cat << EOF > etc/conda/deactivate.d/envvars.sh
@@ -818,7 +818,7 @@ NEMO Runs Directory
 
 Create a :file:`runs/` directory for the NEMO runs and populate it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /nemoShare/MEOPAR/nowcast-sys/
     $ mkdir -p logs/nowcast/
@@ -842,7 +842,7 @@ Create a :file:`wwatch3-runs/` directory tree and populate it with:
 
 * The wwatch3 grid:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ mkdir -p /nemoShare/MEOPAR/nowcast-sys/wwatch3-runs/grid
       $ cd /nemoShare/MEOPAR/nowcast-sys/wwatch3-runs/
@@ -855,7 +855,7 @@ Create a :file:`wwatch3-runs/` directory tree and populate it with:
 
 * Directory for wind forcing:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ mkdir -p /nemoShare/MEOPAR/nowcast-sys/wwatch3-runs/wind
 
@@ -872,7 +872,7 @@ Create a :file:`wwatch3-runs/` directory tree and populate it with:
 
 * Directory for current forcing:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ mkdir -p /nemoShare/MEOPAR/nowcast-sys/wwatch3-runs/current
 
@@ -896,7 +896,7 @@ Here are some useful bash loop one-liners for operating on collections of comput
 If compute node instances are group-launched,
 their hostnames can be set with:
 
-.. code-block:: bash
+.. code-block:: console
 
     for n in {1..8}
     do
@@ -906,7 +906,7 @@ their hostnames can be set with:
 
 Mount shared storage via NFS from head node:
 
-.. code-block:: bash
+.. code-block:: console
 
     for n in {1..8}
     do
@@ -917,7 +917,7 @@ Mount shared storage via NFS from head node:
 
 Confirm whether or not :file:`/nemoShare/MEOPAR/` is a mount point:
 
-.. code-block:: bash
+.. code-block:: console
 
     for n in {1..8}
     do
@@ -927,7 +927,7 @@ Confirm whether or not :file:`/nemoShare/MEOPAR/` is a mount point:
 
 Confirm that :file:`/nemoShare/MEOPAR/` has the shared storage mounts:
 
-.. code-block:: bash
+.. code-block:: console
 
     for n in {1..8}
     do

--- a/docs/deployment/arbutus_cloud.rst
+++ b/docs/deployment/arbutus_cloud.rst
@@ -379,6 +379,7 @@ Confirm that the :ref:`PersistentSharedStorage` volume is attached on ``vdc`` wi
 The expected output is like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
     vda
@@ -399,6 +400,7 @@ Format the volume with an `ext4` file system and confirm:
 The expected output is like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     NAME    FSTYPE LABEL           UUID                                 MOUNTPOINT
     vda

--- a/docs/deployment/operations.rst
+++ b/docs/deployment/operations.rst
@@ -46,7 +46,7 @@ So is the `sarracenia client`_ that maintains mirrors of the HRDPS forecast file
 
 Start the nowcast system and sarracenia client with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ source activate /results/nowcast-sys/nowcast-env
     (/results/nowcast-sys/nowcast-env)$ supervisord --configuration $NOWCAST_CONFIG/supervisord.ini
@@ -56,7 +56,7 @@ Start the nowcast system and sarracenia client with:
 The https://salishsea.eos.ubc.ca website app is also managed by `supervisor`_.
 Start it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ source activate /SalishSeaCast/salishsea-site-env
     (/SalishSeaCast/salishsea-site-env)$ supervisord --configuration $SALISHSEA_SITE/supervisord-prod.ini
@@ -68,7 +68,7 @@ System Management
 `supervisorctl`_ is the command-line interface for interacting with the processes that are running under :command:`supervisord`.
 Start it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ source activate /results/nowcast-sys/nowcast-env
     (/results/nowcast-sys/nowcast-env)$ supervisorctl --configuration $NOWCAST_CONFIG/supervisord.ini
@@ -102,14 +102,14 @@ Use ``quit`` or ``exit`` to exit from :command:`supervisorctl`.
 :command:`sr_subscribe` is run in ``foreground`` mode instead of daemonized so that it can be managed by ::command:`supervisord`.
 Use :command:`supervisorctl` to view the :command:`sr_subscribe` log files:\
 
-.. code-block:: bash
+.. code-block:: console
 
     $ source activate /results/nowcast-sys/nowcast-env
     (/results/nowcast-sys/nowcast-env)$ supervisorctl --configuration $NOWCAST_CONFIG/supervisord.ini tail sr_subscribe-hrdps-west
 
 or
 
-.. code-block:: bash
+.. code-block:: console
 
     (/results/nowcast-sys/nowcast-env)$ supervisorctl --configuration $NOWCAST_CONFIG/supervisord.ini tail sr_subscribe-hydrometric
 

--- a/docs/deployment/optimum.rst
+++ b/docs/deployment/optimum.rst
@@ -31,10 +31,12 @@ the value of :envvar:`HOME` is :file:`/home/sallen/dlatorne`.
 Environment Variables
 =====================
 
-Add these environment variable definitions to :file:`$HOME/.bash_profile`::
+Add these environment variable definitions to :file:`$HOME/.bash_profile`:
 
-  export FORCING=/data/sallen/shared
-  export PROJECT=/home/sallen/dlatorne
+.. code-block:: console
+
+   export FORCING=/data/sallen/shared
+   export PROJECT=/home/sallen/dlatorne
 
 ``optimum`` provides automatically defined environment variables for:
 
@@ -51,10 +53,12 @@ Add these environment variable definitions to :file:`$HOME/.bash_profile`::
 Module Loads
 ============
 
-The default module loads to use on ``optimum`` are::
+The default module loads to use on ``optimum`` are:
 
-  module load OpenMPI/2.1.6/GCC/SYSTEM
-  module load GIT/2/03.03
+.. code-block:: console
+
+   module load OpenMPI/2.1.6/GCC/SYSTEM
+   module load GIT/2/03.03
 
 Loading of those modules is included in :file:`$HOME/.bashrc`.
 
@@ -62,14 +66,16 @@ There is a ``Miniconda/3`` module available for building Python Conda environmen
 Conda environments created with that module loaded are stored in :file:`$HOME/.conda/envs/`.
 
 There is something funky about :program:`REBUILD_NEMO` and the way it uses netCDF that requires a different collection of modules in order to avoid a run-time error about netCDF4 operations on netCDF3 files
-(or vice versa)::
+(or vice versa):
 
-  module load GCC/8.3
-  module load OpenMPI/2.1.6/GCC/8.3
-  module load ZLIB/1.2/11
-  module load use.paustin
-  module load HDF5/1.08/20
-  module load NETCDF/4.6/1
+.. code-block:: console
+
+   module load GCC/8.3
+   module load OpenMPI/2.1.6/GCC/8.3
+   module load ZLIB/1.2/11
+   module load use.paustin
+   module load HDF5/1.08/20
+   module load NETCDF/4.6/1
 
 .. warning::
     The above module loads can *only be used* for build and execution of :program:`REBUILD_NEMO`.

--- a/docs/deployment/optimum.rst
+++ b/docs/deployment/optimum.rst
@@ -92,14 +92,14 @@ Create directory trees for the run preparation directory,
 Git repositories,
 and temporary run directories:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p $PROJECT/SalishSeaCast/hindcast-sys/runs
 
 Store results directories in a tree in :envvar:`SCRATCHDIR`,
 for example:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p #SCRATCHDIR/hindcast.201905/
     $ chmod g+ws #SCRATCHDIR/hindcast.201905/
@@ -110,7 +110,7 @@ Clone Git Repositories
 
 Clone the following repos into :file:`$PROJECT/SalishSeaCast/hindcast-sys/`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/
     $ git clone git@github.com:SalishSeaCast/grid.git
@@ -131,7 +131,7 @@ Build XIOS-2
 
 Symlink the XIOS-2 build configuration files for ``optimum`` from the :file:`XIOS-ARCH` repo clone into the :file:`XIOS-2/arch/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/XIOS-2/arch
     $ ln -s ../../XIOS-ARCH/UBC-EOAS/arch-GCC_OPTIMUM.env
@@ -148,13 +148,13 @@ That version is pointed to by both the ``XIOS-2r1066`` and the ``PROD-hindcast_2
 Git tags,
 so create a branch to checkout the repo at one of those tags:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ git checkout -b PROD-hindcast_201905-v3 PROD-hindcast_201905-v3
 
 and build XIOS-2 with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/XIOS-2/
     $ ./make_xios --arch GCC_OPTIMUM --netcdf_lib netcdf4_seq --job 8
@@ -163,7 +163,7 @@ and build XIOS-2 with:
 
 To clear away all artifacts of a previous build of XIOS-2 use:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/XIOS-2
     $ ./tools/FCM/bin/fcm build --clean
@@ -177,7 +177,7 @@ Create a branch to checkout the repo at an appropriate tag:
 * For hindcast runs,
   something like:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ cd $PROJECT/SalishSeaCast/hindcast-sys/NEMO-3.6-code/
       $ git checkout -b PROD-hindcast_201905-v3 PROD-hindcast_201905-v3
@@ -185,14 +185,14 @@ Create a branch to checkout the repo at an appropriate tag:
 * For research runs,
   something like:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ cd $PROJECT/SalishSeaCast/hindcast-sys/NEMO-3.6-code/
       $ git checkout -b fluxes fluxes
 
 Build NEMO-3.6 with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/NEMO-3.6-code/NEMOGCM/CONFIG
     $ XIOS_HOME=$PROJECT/SalishSeaCast/hindcast-sys/XIOS-2/ ./makenemo -m GCC_OPTIMUM -n SalishSeaCast -j8
@@ -200,7 +200,7 @@ Build NEMO-3.6 with:
 :program:`REBUILD_NEMO` requires a different collection of modules to be loaded for build and execution.
 Build it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ module load GCC/8.3
     $ module load OpenMPI/2.1.6/GCC/8.3
@@ -217,7 +217,7 @@ Install Python Packages
 
 Load the ``Miniconda/3`` module and create a Conda environment:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ module load Miniconda/3
     $ conda create -n salishseacast -c conda-forge python=3 pip arrow \
@@ -227,7 +227,7 @@ Load the ``Miniconda/3`` module and create a Conda environment:
 
 Install the SalishSeaCast NEMO-Cmd and SalishSeaCmd packages from their repo clones:
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishseacast)$ cd $PROJECT/SalishSeaCast/hindcast-sys/
     (salishseacast)$ python -m pip install --editable NEMO-Cmd/
@@ -239,21 +239,21 @@ Populate Run Preparation Directory
 
 Copy the :file:`namelist.time` namelist section template file from the :file:`SS-run-sets` repo clone into the :file:`$PROJECT/SalishSeaCast/hindcast-sys/runs/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/runs/
     $ cp ../SS-run-sets/v201905/hindcast/namelist.time_template namelist.time
 
 Symlink the run description YAML template file from the :file:`SS-run-sets` repo clone into the :file:`$PROJECT/SalishSeaCast/hindcast-sys/runs/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd $PROJECT/SalishSeaCast/hindcast-sys/runs/
     $ ln -s ../SS-run-sets/v201905/hindcast/optimum_hindcast_template.yaml hindcast_template.yaml
 
 Create and populate forcing directory trees with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p $FORCING/SalishSeaCast/forcing/atmospheric/GEM2.5/gemlam
     $ mkdir -p $FORCING/SalishSeaCast/forcing/atmospheric/GEM2.5/operational

--- a/docs/deployment/orcinus.rst
+++ b/docs/deployment/orcinus.rst
@@ -31,7 +31,7 @@ temporary run directories,
 and results directories,
 and set their groups and permissions:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /home/dlatorne/nowcast-agrif-sys/runs
     $ chgrp wg-moad /home/dlatorne/nowcast-agrif-sys/
@@ -47,7 +47,7 @@ Clone Git Repositories
 
 Clone the following repos into :file:`/home/dlatorne/nowcast-agrif-sys/`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/
     $ git clone git@github.com:SalishSeaCast/grid.git
@@ -67,7 +67,7 @@ Build XIOS-2
 
 Symlink the XIOS-2 build configuration files for ``orcinus`` from the :file:`XIOS-ARCH` repo clone into the :file:`XIOS-2/arch/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/XIOS-2/arch
     $ ln -s ../../XIOS-ARCH/UBC-EOAS/arch-X64_ORCINUS.fcm
@@ -75,7 +75,7 @@ Symlink the XIOS-2 build configuration files for ``orcinus`` from the :file:`XIO
 
 and build XIOS-2 with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/XIOS-2
     $ ./make_xios --arch X64_ORCINUS --netcdf_lib netcdf4_seq --job 8
@@ -84,10 +84,10 @@ and build XIOS-2 with:
 
 To clear away all artifacts of a previous build of XIOS-2 use:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd /home/dlatorne/nowcast-agrif-sys/XIOS-2
-    ./tools/FCM/bin/fcm build --clean
+    $ cd /home/dlatorne/nowcast-agrif-sys/XIOS-2
+    $ ./tools/FCM/bin/fcm build --clean
 
 
 Build NEMO-3.6
@@ -95,7 +95,7 @@ Build NEMO-3.6
 
 Build NEMO-3.6 and :program:`rebuild_nemo.exe`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/NEMO-3.6-code/NEMOGCM/CONFIG
     $ ./makenemo -m X64_ORCINUS -n SMELTAGRIF -j8
@@ -108,7 +108,7 @@ Install Python Packages
 
 The Python packages that the system depends on are installed as user packages in :file:`/home/dlatorne/.local/bin/` with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/
     $ python3 -m pip install --user --editable NEMO-Cmd/
@@ -120,7 +120,7 @@ Populate Run Preparation Directory Tree
 
 Copy the :file:`namelist.time` namelist section files from the :file:`SS-run-sets` repo clone into the :file:`/home/dlatorne/nowcast-agrif-sys/runs/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/runs/
     $ cp ../SS-run-sets/v201702/smelt-agrif/namelist.time.template namelist.time
@@ -129,14 +129,14 @@ Copy the :file:`namelist.time` namelist section files from the :file:`SS-run-set
 
 Symlink the run description YAML template files from the :file:`SS-run-sets` repo clone into the :file:`/home/dlatorne/nowcast-agrif-sys/runs/` directory:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/runs/
     $ ln -s ../SS-run-sets/v201702/smelt-agrif/orcinus_nowcast_template.yaml nowcast-agrif_template.yaml
 
 Create and populate forcing sub-directories with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /home/dlatorne/nowcast-agrif-sys/runs/
     $ mkdir -p LiveOcean NEMO-atmos rivers ssh
@@ -159,7 +159,7 @@ Build Nesting Tools
 
 Clone Michael Dunphies' debugged version of the nesting tools for AGRIF from :file:`NEMO-3.6-code/NEMOGCM/TOOLS/NESTING/` on to ``salish``:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh salish
     $ cd /data/dlatorne/MEOPAR/
@@ -167,7 +167,7 @@ Clone Michael Dunphies' debugged version of the nesting tools for AGRIF from :fi
 
 Build the nesting tools suite of Fortran programs with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS
     $ ./maketools -n NESTING -m GCC_SALISH
@@ -178,7 +178,7 @@ Generate Sub-grid Files
 
 Set up a working directory tree in which to generate the sub-grid files:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/
     $ mkdir -p agrif-nesting/BaynesSound agrif-nesting/HaroStrait
@@ -199,7 +199,7 @@ use :program:`agrif_create_coordinates.exe` to create the sub-grid coordinates f
 (path provided in the :file:`namelist.nesting.BaynesSound` file),
 and add it to the ``grid`` repo:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/agrif-nesting/BaynesSound/
     $ /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS/NESTING/agrif_create_coordinates.exe \
@@ -213,7 +213,7 @@ and add it to the ``grid`` repo:
 
 Similarly for the Haro Strait sub-grid:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/agrif-nesting/HaroStrait/
     $ /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS/NESTING/agrif_create_coordinates.exe \
@@ -233,7 +233,7 @@ Bathymetry
     Need to understand the details of how sub-grid bathymetries are generated.
     They appear to be based on :file:`/home/mdunphy/MEOPAR/WORK/Bathy-201702/BC3/BC3_For_Nesting_Tools.nc` and a ``bathymetry`` namelist like:
 
-    .. code-block:: bash
+    .. code-block:: fortran
 
         &bathymetry
             new_topo = true
@@ -262,7 +262,7 @@ we can construct an acceptable rivers biological tracers forcing file for the Ba
 Calculate the :file:`rivers-climatology/bio/subgrids/BaynesSound/bio/rivers_bio_tracers_mean.nc`,
 and add it to the ``rivers-climatology`` repo:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd rivers-climatology/bio
     $ mkdir -p ../subgrids/BaynesSound/bio
@@ -283,7 +283,7 @@ For the Baynes Sound sub-grid,
 use :program:`agrif_create_restart.exe` to create the sub-grid physics restart file from the full domain physics restart file,
 and upload both files to the appropriate run results directory on :`s``:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/agrif-nesting/BaynesSound/
     $ /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS/NESTING/agrif_create_restart.exe \
@@ -297,7 +297,7 @@ Note that the time step number in the Baynes Sound sub-grid restart file name is
 
 Similarly for the Haro Strait sub-grid:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/agrif-nesting/HaroStrait/
     $ /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS/NESTING/agrif_create_restart.exe \
@@ -318,7 +318,7 @@ For the Baynes Sound sub-grid,
 use :program:`agrif_create_restart_trc.exe` to create the sub-grid tracer restart file from the full domain tracer restart file,
 and upload both files to the appropriate run results directory on :`s``:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/agrif-nesting/BaynesSound/
     $ /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS/NESTING/agrif_create_restart_trc.exe \
@@ -333,7 +333,7 @@ Note that the time step number in the Baynes Sound sub-grid restart file name is
 For Haro Strait,
 start by using :program:`agrif_create_restart_trc.exe` to create the sub-grid tracer restart file from the full domain tracer restart file:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /results/nowcast-sys/agrif-nesting/HaroStrait/
     $ /data/dlatorne/MEOPAR/NestingTools/NEMOGCM/TOOLS/NESTING/agrif_create_restart_trc.exe \
@@ -344,7 +344,7 @@ For some reason :program:`agrif_create_restart_trc.exe` fails to store the varia
 in the file it produces.
 To deal with that we duplicate the ``TRNTRA`` field values as ``TRBTRA`` and append that variable to the file:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ncks -4 -O -v TRNTRA 1_SalishSea_02935440_restart_trc.nc TRNTRA.nc
     $ ncks -4 -O 1_SalishSea_02935440_restart_trc.nc 1_SalishSea_02935440_restart_trc.nc
@@ -353,7 +353,7 @@ To deal with that we duplicate the ``TRNTRA`` field values as ``TRBTRA`` and app
 
 and upload the file to the appropriate run results directory on :`s``:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ scp 1_SalishSea_02935440_restart_trc.nc \
         orcinus:/global/scratch/dlatorne/nowcast-agrif/12may18/1_SalishSea_11741760_restart_trc.nc

--- a/docs/deployment/skookum.rst
+++ b/docs/deployment/skookum.rst
@@ -27,7 +27,7 @@ Git Repositories
 
 Clone the following repos into :file:`/SalishSeaCast/`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast/
     $ git clone git@github.com:SalishSeaCast/grid.git
@@ -62,7 +62,7 @@ The Python packages that the system depends on are installed in conda environmen
 
 For the ``SalishSeaCast`` automation system:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast/
     $ mamba env create \
@@ -83,7 +83,7 @@ rivers hydrometric files from the `ECCC MSC datamart service`_:
 .. _sarracenia client: https://github.com/MetPX/sarracenia/blob/v2_dev/doc/sr_subscribe.1.rst
 .. _ECCC MSC datamart service: https://dd.weather.gc.ca/
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast/
     $ mamba env create \
@@ -96,7 +96,7 @@ For the `salishsea-site web app`_ that is mounted at https://salishsea.eos.ubc.c
 
 .. _salishsea-site web app: https://github.com/SalishSeaCast/salishsea-site
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast
     $ mamba env create \
@@ -116,7 +116,7 @@ Add the following files to the :file:`/SalishSeaCast/nowcast-env` environment to
 automatically :command:`export` the environment variables required by the nowcast system
 when the environment is activated:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast/nowcast-env
     $ mkdir -p etc/conda/activate.d
@@ -136,7 +136,7 @@ when the environment is activated:
 
 and :command:`unset` them when it is deactivated.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p etc/conda/deactivate.d
     $ cat << EOF > etc/conda/deactivate.d/envvars.sh
@@ -164,7 +164,7 @@ sarracenia client when the environment is activated and :command:`unset` them wh
 environment is deactivated.
 To see the variables and their values:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast/sarracenia-env
     $ source activate /SalishSeaCast/salishsea-site-env
@@ -178,7 +178,7 @@ Add the following files to the :file:`/SalishSeaCast/salishsea-site-env` environ
 automatically :command:`export` the environment variables required by the
 https://salishsea.eos.ubc.ca website app when the environment is activated:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd /SalishSeaCast/salishsea-site-env
     $ mkdir -p etc/conda/activate.d
@@ -193,7 +193,7 @@ https://salishsea.eos.ubc.ca website app when the environment is activated:
 
 and :command:`unset` them when it is deactivated.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p etc/conda/deactivate.d
     $ cat << EOF > etc/conda/deactivate.d/envvars.sh
@@ -212,7 +212,7 @@ Nowcast Runs Directories
 On the hosts where the nowcast system NEMO runs will be executed create a
 :file:`runs/` directory and populate it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ chmod g+ws runs
     $ cd runs/
@@ -239,7 +239,7 @@ ECCC MSC Datamart Mirror Directories
 Create directories on ``skookum`` for storage of the HRDPS forecast files and
 rivers hydrometric files maintained by the `sarracenia client`_:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /SalishSeaCast/datamart/hrdps-west
     $ mkdir -p /SalishSeaCast/datamart/hydrometric
@@ -251,7 +251,7 @@ Logging Directories
 Create directories on ``skookum`` for storage of the nowcast system and
 `salishsea-site web app`_ log files:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /SalishSeaCast/logs/nowcast
     $ mkdir -p /SalishSeaCast/logs/salishsea-site
@@ -265,7 +265,7 @@ A collection of static file assets for the `salishsea-site web app`_ are stored 
 Create the that directory,
 and the directories for results visualization figures from the NEMO model runs with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /results/nowcast-sys/figures
     $ chmod g+ws /results/nowcast-sys/figures
@@ -280,7 +280,7 @@ and the directories for results visualization figures from the NEMO model runs w
 Create directories for results visualization figures from the
 FVCOM Vancouver Harbour and Lower Fraser River model runs with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /results/nowcast-sys/figures/fvcom/forecast-x2
     $ mkdir -p /results/nowcast-sys/figures/fvcom/nowcast-r12
@@ -289,7 +289,7 @@ FVCOM Vancouver Harbour and Lower Fraser River model runs with:
 Create directories for results visualization figures from the
 WaveWatch III® Strait of Georgia amd Juan de Fuca Strait wave model runs with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /results/nowcast-sys/figures/wwatch3/forecast
     $ mkdir -p /results/nowcast-sys/figures/wwatch3/forecast2
@@ -297,13 +297,13 @@ WaveWatch III® Strait of Georgia amd Juan de Fuca Strait wave model runs with:
 Create a directory for visualization figures generated during preparation of the
 forcing files for the NEMO model runs with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /results/nowcast-sys/figures/monitoring
 
 Create a directory for storm surge alert ATOM feed with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /results/nowcast-sys/figures/storm-surge/atom
 
@@ -311,7 +311,7 @@ Finally,
 create a directory and symlinks for the images used on the index page of
 https://salishsea.eos.ubc.ca/ with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mkdir -p /results/nowcast-sys/figures/salishsea-site/static/img/index_page
     $ cd /results/nowcast-sys/figures/salishsea-site/static/img/index_page
@@ -340,7 +340,7 @@ we use a persistent dask cluster on ``salish`` that the worker dispatches tasks 
 
 Create a :program:`tmux` session on ``salish`` for the dask cluster:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ tmux new -s make_averaged_dataset
 
@@ -349,7 +349,7 @@ activate the :file:`/SalishSeaCast/nowcast-env` environment,
 and launch the :command:`dask-scheduler` with its serving port on 4386,
 and its dashboard port on 4387:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mamba activate /SalishSeaCast/nowcast-env
     (/SalishSeaCast/nowcast-env)$ dask scheduler --port 4386 --dashboard-address :4387
@@ -366,7 +366,7 @@ and launch the 4 :command:`dask worker` processes with these properties:
 * workers restart every 3600 seconds with 60 second random staggering of their restart times
 * workers communicate with the scheduler on port 4386
 
-.. code-block:: bash
+.. code-block:: console
 
     $ mamba activate /SalishSeaCast/nowcast-env
     (/SalishSeaCast/nowcast-env)$ dask worker --nworkers=4 --nthreads=1 --memory-limit 64G \
@@ -383,7 +383,7 @@ Use :kbd:`Control-b ,` to rename the :program:`tmux` terminal to ``dask-workers`
 
 Generate a passphrase-less RSA key pair to use for connections to most remote hosts:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh-keygen -t rsa -f $HOME/.ssh/SalishSeaNEMO-nowcast_id_rsa -C SalishSeaNEMO-nowcast
 
@@ -392,15 +392,15 @@ Use :command:`ssh-copy-id` to install the public key on ``arbutus``,
 and ``orcinus``;
 e.g.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ ssh-copy-id -i $HOME/.ssh/SalishSeaNEMO-nowcast_id_rsa arbutus.cloud
 
 Generate a passphrase-less ED25519 key pair to use for connections to the ``nibi`` HPC cluster:
 
-.. code-block:: bash
+.. code-block:: console
 
-    ssh-keygen -t ed25519 -f $HOME/.ssh/SalishSeaCast_robot.nibi_ed25519 -C "SalishSeaCast robot.nibi"
+    $ ssh-keygen -t ed25519 -f $HOME/.ssh/SalishSeaCast_robot.nibi_ed25519 -C "SalishSeaCast robot.nibi"
 
 Edit the public key to prefix it with the constraint predicates necessary for automation in the
 context of multuifactor authentication on the ``nibi`` cluster.

--- a/docs/figures/create_fig_module.rst
+++ b/docs/figures/create_fig_module.rst
@@ -877,6 +877,6 @@ The ``SalishSeaNowcast`` package uses the `black`_ code formatting tool to maint
 Before each commit of your figure module please run :program:`black` to automatically format your code.
 For our example :py:mod:`~nowcast.figures.research.tracer_thalweg_and_surface` module the command would be:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ black nowcast/figures/research/tracer_thalweg_and_surface.py

--- a/docs/figures/fig_dev_env.rst
+++ b/docs/figures/fig_dev_env.rst
@@ -65,7 +65,7 @@ in a directory like :file:`MEOPAR/`,
 and with the capitalization shown on the left above,
 you can create and activate a figures development environment with these commands:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd SalishSeaNowcast
     $ conda env create -f envs/environment-fig-dev.yaml
@@ -83,6 +83,6 @@ The ``--editable`` option in the :command:`pip install` command above installs t
 
 To deactivate the environment use:
 
-.. code-block:: bash
+.. code-block:: console
 
     (nowcast-fig-dev)$ conda deactivate

--- a/docs/figures/make_figure_calls.rst
+++ b/docs/figures/make_figure_calls.rst
@@ -33,7 +33,7 @@ We'll use the :py:mod:`nowcast.figures.research.tracer_thalweg_and_surface` figu
 You should run your test notebooks and :py:mod:`~nowcast.workers.make_plots` worker tests in a :ref:`NowcastFiguresDevEnv`.
 You can activate it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ source activate nowcast-fig-dev
 
@@ -192,7 +192,7 @@ We can test that we have set up the necessary dataset loading and registered our
    activate your :ref:`NowcastFiguresDevEnv`,
    and navigate to your :file:`SalishSeaNowcast/` directory:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        $ source activate nowcast-fig-dev
        (nowcast-fig-dev)$ cd SalishSeaNowcast/
@@ -200,7 +200,7 @@ We can test that we have set up the necessary dataset loading and registered our
 #. Set up 2 environment variables that the nowcast system expects to find,
    and create a temporary logging directory for it to use:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        (nowcast-fig-dev)$ export NOWCAST_LOGS=/tmp/$USER
        (nowcast-fig-dev)$ export NOWCAST_ENV=$CONDA_PREFIX
@@ -209,7 +209,7 @@ We can test that we have set up the necessary dataset loading and registered our
 
 #. Run the :py:mod:`make_plots` worker:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        (nowcast-fig-dev)$ python -m nowcast.workers.make_plots config/nowcast.yaml nowcast-green research --debug --test-figure nitrate_thalweg_and_surface --run-date 2017-04-29
 

--- a/docs/figures/make_figure_calls.rst
+++ b/docs/figures/make_figure_calls.rst
@@ -225,24 +225,30 @@ We can test that we have set up the necessary dataset loading and registered our
    * ``nitrate_thalweg_and_surface``, the key of the :py:func:`make_figure` call to test
    * ``--run-date``, to say what date's run results to render the figure for
 
-   The output of a successful test should look something like::
+   The output of a successful test should look something like:
 
-     2017-05-05 17:11:16,119 INFO [make_plots] running in process 2993
-     2017-05-05 17:11:16,120 INFO [make_plots] read config from config/nowcast.yaml
-     2017-05-05 17:11:16,120 DEBUG [make_plots] **debug mode** no connection to manager
-     2017-05-05 17:11:16,358 DEBUG [make_plots] starting nowcast.figures.research.tracer_thalweg_and_surface.make_figure
-     2017-05-05 17:11:18,645 INFO [make_plots] /results/nowcast-sys/figures/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg saved
-     2017-05-05 17:11:18,646 INFO [make_plots] research plots for 2017-04-29 nowcast-green completed
-     2017-05-05 17:11:18,647 DEBUG [make_plots] **debug mode** message that would have been sent to manager: (success nowcast-green research nowcast-green research plots produced)
-     2017-05-05 17:11:18,647 DEBUG [make_plots] shutting down
+   .. code-block:: text
 
-   It is particularly important that your output contains the line that tells you that your figure was saved::
+      2017-05-05 17:11:16,119 INFO [make_plots] running in process 2993
+      2017-05-05 17:11:16,120 INFO [make_plots] read config from config/nowcast.yaml
+      2017-05-05 17:11:16,120 DEBUG [make_plots] **debug mode** no connection to manager
+      2017-05-05 17:11:16,358 DEBUG [make_plots] starting nowcast.figures.research.tracer_thalweg_and_surface.make_figure
+      2017-05-05 17:11:18,645 INFO [make_plots] /results/nowcast-sys/figures/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg saved
+      2017-05-05 17:11:18,646 INFO [make_plots] research plots for 2017-04-29 nowcast-green completed
+      2017-05-05 17:11:18,647 DEBUG [make_plots] **debug mode** message that would have been sent to manager: (success nowcast-green research nowcast-green research plots produced)
+      2017-05-05 17:11:18,647 DEBUG [make_plots] shutting down
 
-     INFO [make_plots] /results/nowcast-sys/figures/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg saved
+   It is particularly important that your output contains the line that tells you that your figure was saved:
 
-   You can transform that path into a URL like::
+   .. code-block:: text
 
-     https://salishsea.eos.ubc.ca/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg
+      INFO [make_plots] /results/nowcast-sys/figures/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg saved
+
+   You can transform that path into a URL like:
+
+   .. code-block:: text
+
+      https://salishsea.eos.ubc.ca/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg
 
    and visually check your figure in your browser.
 

--- a/docs/figures/make_figure_calls.rst
+++ b/docs/figures/make_figure_calls.rst
@@ -228,6 +228,7 @@ We can test that we have set up the necessary dataset loading and registered our
    The output of a successful test should look something like:
 
    .. code-block:: text
+      :class: no-copybutton
 
       2017-05-05 17:11:16,119 INFO [make_plots] running in process 2993
       2017-05-05 17:11:16,120 INFO [make_plots] read config from config/nowcast.yaml
@@ -241,12 +242,14 @@ We can test that we have set up the necessary dataset loading and registered our
    It is particularly important that your output contains the line that tells you that your figure was saved:
 
    .. code-block:: text
+      :class: no-copybutton
 
       INFO [make_plots] /results/nowcast-sys/figures/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg saved
 
    You can transform that path into a URL like:
 
    .. code-block:: text
+      :class: no-copybutton
 
       https://salishsea.eos.ubc.ca/test/nowcast-green/29apr17/nitrate_thalweg_and_surface_29apr17.svg
 

--- a/docs/figures/site_view_fig_metadata.rst
+++ b/docs/figures/site_view_fig_metadata.rst
@@ -32,7 +32,7 @@ We'll use the :py:mod:`nowcast.figures.research.tracer_thalweg_and_surface` figu
 You should run your local ``salishsea`` website server for testing in a :ref:`NowcastFiguresDevEnv`.
 You can activate it with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ source activate nowcast-fig-dev
 
@@ -83,16 +83,16 @@ Testing the Website View
 #. If you haven't done so already,
    activate your :ref:`NowcastFiguresDevEnv`:
 
-   .. code-block:: bash
+   .. code-block:: console
 
-       $ source activate nowcast-fig-dev\
+       $ source activate nowcast-fig-dev
 
 #. Assuming that you have successfully run the :py:mod:`make_plots` worker :ref:`in test mode<RunningMakePlotsWorkerToTestAFigure>` for your figure,
    navigate to your :file:`SalishSeaNowcast/` directory,
    set up the 2 environment variables that the nowcast system expects to find,
    create a temporary logging directory for it to use:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        (nowcast-fig-dev)$ export NOWCAST_LOGS=/tmp/$USER
        (nowcast-fig-dev)$ export NOWCAST_ENV=$CONDA_PREFIX
@@ -103,14 +103,14 @@ Testing the Website View
    For our test of the :py:mod:`nowcast.figures.research.tracer_thalweg_and_surface` figure module,
    the command would be like:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        (nowcast-fig-dev)$ python -m nowcast.workers.make_plots config/nowcast.yaml nowcast-green research --debug --run-date 2017-05-07
 
 #. Navigate to your :file:`salishsea-site/` directory,
    and launch the local website server with:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        (nowcast-fig-dev)$ cd salishsea-site/
        (nowcast-fig-dev)$ pserve --reload development.ini
@@ -151,6 +151,6 @@ The :kbd:`salishsea_site` package uses the`black`_ code formatting tool to maint
 
 Before each commit of the :py:mod:`salishsea_site.views.salishseacast` module please run :program:`black` to automatically format the code with the command:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ black salishsea_site/views/salishseacast.py

--- a/docs/figures/site_view_fig_metadata.rst
+++ b/docs/figures/site_view_fig_metadata.rst
@@ -115,7 +115,9 @@ Testing the Website View
        (nowcast-fig-dev)$ cd salishsea-site/
        (nowcast-fig-dev)$ pserve --reload development.ini
 
-   You should see output like::
+   You should see output like:
+
+   .. code-block:: text
 
      Starting monitor for PID 10564.
      Starting server in PID 10564.

--- a/docs/figures/site_view_fig_metadata.rst
+++ b/docs/figures/site_view_fig_metadata.rst
@@ -118,10 +118,11 @@ Testing the Website View
    You should see output like:
 
    .. code-block:: text
+      :class: no-copybutton
 
-     Starting monitor for PID 10564.
-     Starting server in PID 10564.
-     serving on http://0.0.0.0:6543
+      Starting monitor for PID 10564.
+      Starting server in PID 10564.
+      serving on http://0.0.0.0:6543
 
    but the PID number will be different.
    The web server is now running in this terminal session.

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -236,6 +236,7 @@ to do a clean build of the documentation.
 The output looks something like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     Removing everything under '_build'...
     Running Sphinx v8.1.3
@@ -306,6 +307,7 @@ use:
 The output looks something like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     Removing everything under '_build'...
     Running Sphinx v8.1.3
@@ -516,6 +518,7 @@ to run the test suite.
 The output looks something like:
 
 .. code-block:: text
+   :class: no-copybutton
 
     ================================ test session starts =================================
     platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -101,7 +101,7 @@ Clone the code and documentation `repository`_ from GitHub with:
 
 .. _repository: https://github.com/SalishSeaCast/SalishSeaNowcast
 
-.. code-block:: bash
+.. code-block:: console
 
     $ git clone git@github.com:SalishSeaCast/SalishSeaNowcast.git
 
@@ -136,7 +136,7 @@ and building the documentation with the commands below.
 If you have not done so already,
 you can clone those repos with:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd SalishSeaNowcast/..
     $ git clone git@github.com:43ravens/NEMO_Nowcast.git
@@ -152,7 +152,7 @@ please ensure that they are up to date.
 Assuming that those repos are cloned beside your ``SalishSeaNowcast`` clone,
 the commands below install the packages into your ``salishsea-nowcast`` development environment.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd SalishSeaNowcast
     $ conda env create -f envs/environment-dev.yaml
@@ -169,7 +169,7 @@ The ``--editable`` option in the :command:`pip install` command above installs t
 
 To deactivate the environment use:
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishsea-nowcast)$ conda deactivate
 
@@ -197,7 +197,7 @@ To install the `pre-commit` hooks in a newly cloned repo,
 activate the conda development environment,
 and run :command:`pre-commit install`:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd SalishSeaNowcast
     $ conda activate salishsea-nowcast
@@ -228,7 +228,7 @@ use:
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _Sphinx: https://www.sphinx-doc.org/en/master/
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishsea-nowcast)$ (cd docs && make clean html)
 
@@ -298,10 +298,10 @@ Sphinx also provides a link checker utility which can be run to find broken or r
 With your ``salishsea-nowcast`` environment activated,
 use:
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishsea-nowcast)$ cd SalishSeaNowcast/docs/
-    (salishsea-nowcast) docs$ make linkcheck
+    (salishsea-nowcast)$ make linkcheck
 
 The output looks something like:
 
@@ -507,7 +507,7 @@ The `pytest`_ tool is used for test parametrization and as the test runner for t
 With your ``salishsea-nowcast`` development environment activated,
 use:
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishsea-nowcast)$ cd SalishSeaNowcast/
     (salishsea-nowcast)$ pytest
@@ -598,7 +598,7 @@ You can monitor what lines of code the test suite exercises using the `coverage.
 .. _coverage.py: https://coverage.readthedocs.io/en/latest/
 .. _pytest-cov: https://pytest-cov.readthedocs.io/en/latest/
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishsea-nowcast)$ cd SalishSeaNowcast/
     (salishsea-nowcast)$ pytest --cov=./
@@ -608,7 +608,7 @@ The test coverage report will be displayed below the test suite run output.
 Alternatively,
 you can use
 
-.. code-block:: bash
+.. code-block:: console
 
     (salishsea-nowcast)$ pytest --cov=./ --cov-report html
 

--- a/docs/pkg_development.rst
+++ b/docs/pkg_development.rst
@@ -533,7 +533,7 @@ The output looks something like:
     tests/workers/test_watch_NEMO_hindcast.py ...........................................
     ..................                                                             [  7%]
     tests/workers/test_update_forecast_datasets.py ......................................
-`   ................................                                               [ 10%]
+    ................................                                               [ 10%]
     tests/release_mgmt/test_tag_release.py .........                               [ 11%]
     tests/workers/test_make_ww3_wind_file.py ........................              [ 12%]
     tests/workers/test_make_CHS_currents_file.py ........................          [ 13%]

--- a/docs/worker_failures.rst
+++ b/docs/worker_failures.rst
@@ -75,7 +75,7 @@ then run the worker as follows:
    activate the production nowcast :program:`conda` environment,
    and navigate to the nowcast configuration and logging directory:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        $ ssh skookum
        skookum$ conda activate /SalishSeaCast/nowcast-env
@@ -84,7 +84,7 @@ then run the worker as follows:
    for the appropriate forecast with debug logging,
    for example:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        (/SalishSeaCast/nowcast-env)skookum$ python -m nowcast.workers.download_weather $NOWCAST_YAML 12 2.5km --debug
 
@@ -117,7 +117,7 @@ You can use the ``-h`` or ``--help`` flags to get a usage message that explains
 the worker's required arguments,
 and its option flags:
 
-.. code-block:: bash
+.. code-block:: console
 
     (nowcast)$ python -m nowcast.workers.download_weather --help
 
@@ -165,7 +165,7 @@ That can be accomplished as follows:
 #. Activate your nowcast :program:`conda` environment,
    and navigate to your nowcast development and testing environment:
 
-   .. code-block:: bash
+   .. code-block:: console
 
        $ source activate salishsea-nowcast
        (nowcast)$ cd MEOPAR/nowcast/
@@ -186,7 +186,7 @@ That can be accomplished as follows:
         The directory :file:`/ocean/<your_userid>/MEOPAR/GRIB/` must exist.
         Create it if necessary with:
 
-        .. code-block:: bash
+        .. code-block:: console
 
             $ mkdir -p /ocean/<your_userid>/MEOPAR/GRIB/
 

--- a/docs/worker_failures.rst
+++ b/docs/worker_failures.rst
@@ -96,6 +96,7 @@ then run the worker as follows:
    The (abridged) output should look like:
 
    .. code-block:: text
+      :class: no-copybutton
 
         2023-02-24 10:18:07,831 INFO [download_weather] running in process 3006
         2023-02-24 10:18:07,831 INFO [download_weather] read config from /SalishSeaCast/SalishSeaNowcast/config/nowcast.yaml
@@ -122,6 +123,7 @@ and its option flags:
     (nowcast)$ python -m nowcast.workers.download_weather --help
 
 .. code-block:: text
+   :class: no-copybutton
 
     usage: python -m nowcast.workers.download_weather [-h] [--debug] [--run-date RUN_DATE]
            [--no-verify-certs] config_file {12,06,00,18} {1km,2.5km}

--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -90,6 +90,7 @@ dependencies:
 
   # For documentation
   - sphinx==8.1.3
+  - sphinx-copybutton==0.5.2
   - sphinx-notfound-page==1.0.4
   - sphinx-rtd-theme==3.0.0
 

--- a/envs/environment-fig-dev.yaml
+++ b/envs/environment-fig-dev.yaml
@@ -71,6 +71,7 @@ dependencies:
 
   # For documentation
   - sphinx==8.1.3
+  - sphinx-copybutton==0.5.2
   - sphinx-notfound-page==1.0.4
   - sphinx-rtd-theme==3.0.0
 

--- a/envs/environment-linkcheck.yaml
+++ b/envs/environment-linkcheck.yaml
@@ -65,6 +65,7 @@ dependencies:
 
   # For documentation links checking
   - sphinx==8.1.3
+  - sphinx-copybutton==0.5.2
   - sphinx-notfound-page==1.0.4
   - sphinx-rtd-theme==3.0.0
 

--- a/envs/environment-rtd.yaml
+++ b/envs/environment-rtd.yaml
@@ -17,6 +17,7 @@ dependencies:
 
   # Sphinx and extensions
   - sphinx==8.1.3
+  - sphinx-copybutton==0.5.2
   - sphinx-notfound-page==1.0.4
   - sphinx-rtd-theme==3.0.0
 

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -24,7 +24,7 @@ Bottleneck==1.6.0
 Brotli==1.2.0
 cached-property==1.5.2
 Cartopy==0.25.0
-certifi==2026.2.25
+certifi==2026.6.17
 cffi==2.0.0
 cfgrib==0.9.15.1
 cfgv==3.5.0
@@ -114,7 +114,7 @@ numpy-groupies==0.11.3
 numpy-indexed==0.3.7
 openpyxl==3.1.5
 packaging==26.0
-pandas==3.0.2
+pandas==2.3.3
 paramiko==4.0.0
 partd==1.4.2
 pathspec==1.0.4
@@ -177,6 +177,7 @@ snowballstemmer==3.0.1
 sortedcontainers==2.4.0
 soupsieve==2.8.3
 Sphinx==8.1.3
+sphinx-copybutton==0.5.2
 sphinx-notfound-page==1.0.4
 sphinx_rtd_theme==3.0.0
 sphinxcontrib-applehelp==2.0.0

--- a/nowcast/figures/research/tracer_thalweg_and_surface.py
+++ b/nowcast/figures/research/tracer_thalweg_and_surface.py
@@ -34,7 +34,6 @@ https://nbviewer.org/github/SalishSeaCast/SalishSeaNowcast/blob/main/notebooks/f
 
 Development notebook for this module is
 https://nbviewer.org/github/SalishSeaCast/SalishSeaNowcast/blob/main/notebooks/figures/research/DevelopTracerThalwegAndSurfaceModule.ipynb
-
 """
 
 from types import SimpleNamespace

--- a/nowcast/lib.py
+++ b/nowcast/lib.py
@@ -33,11 +33,13 @@ def configure_logging(config, logger, debug, email=True):
 
     This function assumes that the logger object has been created
     in the module from which the function is called.
-    That is typically done with a module-level commands like::
+    That is typically done with a module-level commands like:
 
-      worker_name = lib.get_module_name()
+    .. code-block:: python
 
-      logger = logging.getLogger(worker_name)
+        worker_name = lib.get_module_name()
+
+        logger = logging.getLogger(worker_name)
 
     :arg config: Configuration data structure.
     :type config: dict


### PR DESCRIPTION
### Summary

This pull request improves the user experience and consistency in the project's documentation by:

- Adding the `sphinx-copybutton` extension to Sphinx's configuration and relevant environments (`dev`, `docs`, and `linkcheck`).
- Configuring `sphinx_copybutton` options in `conf.py` to handle prompts, respected line continuations, and introduced the `no-copybutton` class.
- Standardizing code block syntax and formatting across documentation by replacing inconsistent directives with proper `.. code-block` syntax.
- Suppressing copy buttons for specific command output text blocks.
- Fixing minor issues like indentation in reStructuredText and removing a typo in `pkg_development.rst`.

Co-authored-by: Junie <junie@jetbrains.com>