### PR TITLE
Update timezone handling in `figures.publish.compare_tide_prediction_max_ssh` figure module

### DIFF
--- a/nowcast/figures/publish/compare_tide_prediction_max_ssh.py
+++ b/nowcast/figures/publish/compare_tide_prediction_max_ssh.py
@@ -225,7 +225,7 @@ def _prep_plot_data(
     tracers_ds = xarray.open_dataset(grid_T_hr_path)
     max_ssh_time_utc = (
         arrow.get(str(max_ssh.time.values))
-        .replace(tzinfo=ssh_forecast.attrs["tz_name"])
+        .replace(tzinfo=ssh_forecast.attrs["utc_offset"])
         .to("utc")
     )
     return SimpleNamespace(
@@ -520,9 +520,10 @@ def _plot_ssh_map(ax_map, plot_data, place, theme):
 def _ssh_map_axis_labels(ax_map, place, plot_data, theme):
     max_ssh_time = arrow.get(str(plot_data.max_ssh_field.time_counter.values))
     tz_name = plot_data.ssh_forecast.attrs["tz_name"]
+    utc_offset = plot_data.ssh_forecast.attrs["utc_offset"]
     ax_map.set_title(
         f"Sea Surface Height at "
-        f'{max_ssh_time.to(tz_name).format("YYYY-MM-DD HH:mm")} {tz_name}',
+        f'{max_ssh_time.to(utc_offset).format("YYYY-MM-DD HH:mm")} {tz_name}',
         fontproperties=theme.FONTS["axes title"],
         color=theme.COLOURS["text"]["axes title"],
     )

--- a/nowcast/figures/shared.py
+++ b/nowcast/figures/shared.py
@@ -382,10 +382,11 @@ def localize_time(data_array, time_coord="time", local_datetime=None):
     time_values = getattr(data_array, time_coord).values
     if local_datetime is None:
         local_datetime = arrow.get(str(time_values[0])).to("local")
-    tz_offset = local_datetime.tzinfo.utcoffset(local_datetime.datetime)
-    tz_name = local_datetime.tzinfo.tzname(local_datetime.datetime)
+    tz_offset = local_datetime.datetime.utcoffset()
+    tz_name = local_datetime.datetime.tzname()
     numpy_offset = np.timedelta64(tz_offset.days, "D") + np.timedelta64(
         tz_offset.seconds, "s"
     )
     data_array[time_coord] = time_values + numpy_offset
     data_array.attrs["tz_name"] = tz_name
+    data_array.attrs["utc_offset"] = local_datetime.strftime("%:z")


### PR DESCRIPTION
Refactored `figures.shared.localize_time()`:
* Simplified code that gets timezone name.
* Added UTC offset to data array attributes

Updated timezone adjustments in `figures.publish.compare_tide_prediction_max_ssh` figure module to use UTC offset instead of timezone name because `arrow` doesn't like "PDT" any more for timezone adjustments. I suspect that this is due to `arrow=1.4.0` migrating from `pytz` to `ZoneInfo`.