### PR TITLE
Add support for LiveOcean download filename

### DIFF
--- a/nowcast/workers/make_live_ocean_files.py
+++ b/nowcast/workers/make_live_ocean_files.py
@@ -76,6 +76,7 @@ def make_live_ocean_files(parsed_args, config, *args):
         bc_filepath.unlink()
     meshfilename = Path(config["temperature salinity"]["mesh mask"])
     download_dir = Path(config["temperature salinity"]["download"]["dest dir"])
+    download_file = Path(config["temperature salinity"]["download"]["file name"])
     LO_to_SSC_parameters = LiveOcean_parameters.set_parameters(
         config["temperature salinity"]["parameter set"]
     )
@@ -85,6 +86,7 @@ def make_live_ocean_files(parsed_args, config, *args):
         meshfilename=meshfilename,
         bc_dir=bc_dir,
         LO_dir=download_dir,
+        LO_file=download_file,
         LO_to_SSC_parameters=LO_to_SSC_parameters,
     )
     logger.info(f"Stored T&S western boundary conditions file: {filepath}")

--- a/tests/workers/test_make_live_ocean_files.py
+++ b/tests/workers/test_make_live_ocean_files.py
@@ -39,6 +39,7 @@ def config(base_config):
                 temperature salinity:
                   download:
                     dest dir: forcing/LiveOcean/downloaded
+                    file name: low_passed_UBC.nc
                   bc dir: forcing/LiveOcean/boundary_conditions
                   file template: 'LiveOcean_v201905_{:y%Ym%md%d}.nc'
                   mesh mask: grid/mesh_mask201702.nc
@@ -112,6 +113,7 @@ class TestConfig:
             temperature_salinity["download"]["dest dir"]
             == "/results/forcing/LiveOcean/downloaded/"
         )
+        assert temperature_salinity["download"]["file name"] == "low_passed_UBC.nc"
         assert temperature_salinity["parameter set"] == "v201905"
 
 
@@ -157,7 +159,13 @@ class TestMakeLiveOceanFiles:
     @pytest.fixture
     def mock_create_LiveOcean_TS_BCs(config, monkeypatch):
         def _mock_create_LiveOcean_TS_BCs(
-            date, file_template, meshfilename, bc_dir, LO_dir, LO_to_SSC_parameters
+            date,
+            file_template,
+            meshfilename,
+            bc_dir,
+            LO_dir,
+            LO_file,
+            LO_to_SSC_parameters,
         ):
             return (
                 "forcing/LiveOcean/boundary_conditions/LiveOcean_v201905_y2024m07d26.nc"


### PR DESCRIPTION
Updated `make_live_ocean_files` worker to include thenew `file name` configuration item for temperature-salinity downloads. Corresponding tests were modified to validate the new configuration and ensure compatibility.